### PR TITLE
Fixed anisotropic solidification reference grid initialization error- correct branching workflow

### DIFF
--- a/examples/phase_transitions/solidification/anisotropic/solidification.cpp
+++ b/examples/phase_transitions/solidification/anisotropic/solidification.cpp
@@ -50,7 +50,9 @@ template <int dim, typename T> void update(grid<dim,vector<T> >& oldGrid, int st
 
 	ghostswap(oldGrid);
 
-	static grid<dim,T> refGrid(oldGrid,0); // constructor copies only field 0
+	static grid<dim,T> refGrid(oldGrid,0); 
+	for (int i=0; i<nodes(refGrid); ++i) //initialize values for refGrid
+			refGrid(i)=oldGrid(i)[0];
 	grid<dim,vector<T> > newGrid(oldGrid);
 
 	double      dt=5e-5;    // time-step


### PR DESCRIPTION
The proposed changes are intended to ensure the reference grid in the anisotropic solidification example is initialized properly.

This is achieved by explicitly setting the values of the reference grid to those in the old grid before utilizing either in the grid update calculation.

The correct branching workflow has been followed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mesoscale/mmsp/57)
<!-- Reviewable:end -->
