### PR TITLE
vti writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ MMSP is nothing more than a collection of C++ header files that declare a number
  * An ISO compliant C++ compiler (e.g. GCC 2.95 or later)
  * zlib libraries for data compression (e.g. zlib 1.2.7)
  * libpng headers for mmsp2png image generation utility (e.g. libpng12-dev)
+ * libvtk headers for mmsp2vti image generation utility (e.g. libvtk6-dev)
  * MPI libraries if compiling parallel programs (e.g. Open MPI)
 
 *Documentation*

--- a/include/MMSP.grid.cpp
+++ b/include/MMSP.grid.cpp
@@ -1181,10 +1181,14 @@ template<int dim, typename T> void grid<dim,T>::input(const char* filename, int 
 	}
 
 	// grid data type error check
-	std::string type;
+	std::string type, scalar_type;
 	getline(input, type, '\n');
+	scalar_type = "grid:scalar" + type.substr(type.find_last_of(":", 8));
+	if (type != name(*this) && scalar_type == name(*this)) {
+		type = scalar_type;
+	}
 	if (type != name(*this)) {
-		std::cerr << "File read error: wrong data type (" << type << ")." << std::endl;
+		std::cerr << "File read error: wrong data type (" << type << "), expected (" << name(*this) << ")." << std::endl;
 		exit(-2);
 	}
 

--- a/utility/Makefile
+++ b/utility/Makefile
@@ -4,8 +4,8 @@
 
 # compilers/flags
 compiler = g++
-flags = -O2 -Wall -I ../include -I /usr/include/vtk-6.3 -L /usr/lib/x86_64-linux-gnu
-vtklinks = -lvtkCommonCore-6.3 -lvtkCommonDataModel-6.3 -lvtkIOXML-6.3
+flags = -O2 -Wall -I ../include -I /usr/include/vtk -L /usr/lib/x86_64-linux-gnu
+vtklinks = -lvtkCommonCore -lvtkCommonDataModel -lvtkIOXML
 topo = ../algorithms/topology
 
 # conversion programs

--- a/utility/Makefile
+++ b/utility/Makefile
@@ -43,12 +43,8 @@ mmsp2pvd : mmsp2pvd.cpp
 mmsp2tsv : mmsp2tsv.cpp
 	$(compiler) $(flags) $< -o $@ -lz
 
-# convert MMSP grid file to VTK Image file type
-mmsp2vti : mmsp2vti.cpp
-	$(compiler) $(flags) $< -o $@ -lz
-
 # convert MMSP grid file to compressed VTK Image file type
-mmsp2vtz : mmsp2vti.cpp
+mmsp2vti : mmsp2vti.cpp
 	$(compiler) $(flags) $< -o $@ $(vtklinks) -lz
 
 # convert MMSP grid file to XYZ point cloud file type

--- a/utility/Makefile
+++ b/utility/Makefile
@@ -2,9 +2,13 @@
 # GNU makefile for grid conversion programs using MMSP
 # Questions/comments to gruberja@gmail.com (Jason Gruber)
 
+# VTK path
+VTK_SRC = $(shell dirname $(shell locate --limit 1 vtkImageData.h))
+VTK_LIB = $(shell dirname $(shell locate --limit 1 vtkCommonCore.so))
+
 # compilers/flags
 compiler = g++
-flags = -O2 -Wall -I ../include -I /usr/include/vtk -L /usr/lib/x86_64-linux-gnu
+flags = -O2 -Wall -I ../include -I $(VTK_SRC) -L $(VTK_LIB)
 vtklinks = -lvtkCommonCore -lvtkCommonDataModel -lvtkIOXML
 topo = ../algorithms/topology
 

--- a/utility/Makefile
+++ b/utility/Makefile
@@ -4,8 +4,8 @@
 
 # compilers/flags
 compiler = g++
-flags = -O2 -Wall -pedantic -I ../include/
-
+flags = -O2 -Wall -I ../include -I /usr/include/vtk-6.3 -L /usr/lib/x86_64-linux-gnu
+vtklinks = -lvtkCommonCore-6.3 -lvtkCommonDataModel-6.3 -lvtkIOXML-6.3
 topo = ../algorithms/topology
 
 # conversion programs
@@ -35,6 +35,10 @@ mmsp2tsv : mmsp2tsv.cpp
 # convert MMSP grid file to VTK Image file type
 mmsp2vti : mmsp2vti.cpp
 	$(compiler) $(flags) $< -o $@ -lz
+
+# convert MMSP grid file to compressed VTK Image file type
+mmsp2vtz : mmsp2vti.cpp
+	$(compiler) $(flags) -O0 -g $< -o $@ $(vtklinks) -lz
 
 # convert MMSP grid file to XYZ point cloud file type
 mmsp2xyz : mmsp2xyz.cpp

--- a/utility/Makefile
+++ b/utility/Makefile
@@ -2,14 +2,21 @@
 # GNU makefile for grid conversion programs using MMSP
 # Questions/comments to gruberja@gmail.com (Jason Gruber)
 
-# VTK path
+# find VTK libraries
 VTK_SRC = $(shell dirname $(shell locate --limit 1 vtkImageData.h))
 VTK_LIB = $(shell dirname $(shell locate --limit 1 vtkCommonCore.so))
+vtklinks = -lvtkCommonCore -lvtkCommonDataModel -lvtkIOXML
+
+# handle special cases of VTK installation
+VTK_DEB = $(shell locate --limit 1 vtkCommonCore-6.3.so)
+ifneq ($(VTK_DEB), "")
+	VTK_LIB = $(shell dirname $(shell locate --limit 1 vtkCommonCore-6.3.so))
+	vtklinks = -lvtkCommonCore-6.3 -lvtkCommonDataModel-6.3 -lvtkIOXML-6.3
+endif
 
 # compilers/flags
 compiler = g++
 flags = -O2 -Wall -I ../include -I $(VTK_SRC) -L $(VTK_LIB)
-vtklinks = -lvtkCommonCore -lvtkCommonDataModel -lvtkIOXML
 topo = ../algorithms/topology
 
 # conversion programs

--- a/utility/Makefile
+++ b/utility/Makefile
@@ -38,7 +38,7 @@ mmsp2vti : mmsp2vti.cpp
 
 # convert MMSP grid file to compressed VTK Image file type
 mmsp2vtz : mmsp2vti.cpp
-	$(compiler) $(flags) -O0 -g $< -o $@ $(vtklinks) -lz
+	$(compiler) $(flags) $< -o $@ $(vtklinks) -lz
 
 # convert MMSP grid file to XYZ point cloud file type
 mmsp2xyz : mmsp2xyz.cpp

--- a/utility/mmsp2vti.cpp
+++ b/utility/mmsp2vti.cpp
@@ -14,183 +14,183 @@
 
 template<int dim, typename T> void print_scalars(std::string filename, const MMSP::grid<dim,T>& GRID, const int mode)
 {
-	vtkSmartPointer<vtkImageData> vtkData = vtkSmartPointer<vtkImageData>::New();
+	vtkSmartPointer<vtkImageData> scalarData = vtkSmartPointer<vtkImageData>::New();
 
 	if (dim==1) {
-		vtkData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID), 1, 1);
-		vtkData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1, 0, 0, 0, 0);
-		vtkData->SetSpacing(MMSP::dx(GRID), 1, 1);
+		scalarData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID), 1, 1);
+		scalarData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1, 0, 0, 0, 0);
+		scalarData->SetSpacing(MMSP::dx(GRID), 1, 1);
 		#if VTK_MAJOR_VERSION <= 5
-		vtkData->SetScalarTypeToDouble();
-		vtkData->SetNumberOfScalarComponents(1);
+		scalarData->SetScalarTypeToDouble();
+		scalarData->SetNumberOfScalarComponents(1);
 		#else
-		vtkData->AllocateScalars(VTK_DOUBLE, 1);
+		scalarData->AllocateScalars(VTK_DOUBLE, 1);
 		#endif
 
 		MMSP::vector<int> x(1,0);
 		for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
-			double* pixel = static_cast<double*>(vtkData->GetScalarPointer(x[0], 0, 0));
+			double* pixel = static_cast<double*>(scalarData->GetScalarPointer(x[0], 0, 0));
 			if (mode==1) { // --mag
-				pixel[0] = std::sqrt(GRID(x)*GRID(x));
+				*pixel = std::sqrt(GRID(x)*GRID(x));
 			} else {
-				pixel[0] = GRID(x);
+				*pixel = GRID(x);
 			}
 		}
 	} else if (dim==2) {
-		vtkData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID),
+		scalarData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID),
 		                       MMSP::y1(GRID)-MMSP::y0(GRID),
 		                       1);
-		vtkData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1,
+		scalarData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1,
 		                   MMSP::y0(GRID), MMSP::y1(GRID) - 1,
 		                   0, 0);
-		vtkData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), 1);
+		scalarData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), 1);
 		#if VTK_MAJOR_VERSION <= 5
-		vtkData->SetScalarTypeToDouble();
-		vtkData->SetNumberOfScalarComponents(1);
+		scalarData->SetScalarTypeToDouble();
+		scalarData->SetNumberOfScalarComponents(1);
 		#else
-		vtkData->AllocateScalars(VTK_DOUBLE, 1);
+		scalarData->AllocateScalars(VTK_DOUBLE, 1);
 		#endif
 
 		MMSP::vector<int> x(2,0);
 		for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
 			for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
-				double* pixel = static_cast<double*>(vtkData->GetScalarPointer(x[0], x[1], 0));
+				double* pixel = static_cast<double*>(scalarData->GetScalarPointer(x[0], x[1], 0));
 				if (mode==1) { // --mag
-					pixel[0] = std::sqrt(GRID(x)*GRID(x));
+					*pixel = std::sqrt(GRID(x)*GRID(x));
 				} else {
-					pixel[0] = GRID(x);
+					*pixel = GRID(x);
 				}
 			}
 		}
 	} else if (dim==3) {
-		vtkData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID),
+		scalarData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID),
 		                       MMSP::y1(GRID)-MMSP::y0(GRID),
 		                       MMSP::z1(GRID)-MMSP::z0(GRID));
-		vtkData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1,
+		scalarData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1,
 		                   MMSP::y0(GRID), MMSP::y1(GRID) - 1,
 		                   MMSP::z0(GRID), MMSP::z1(GRID) - 1);
-		vtkData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), MMSP::dx(GRID, 2));
+		scalarData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), MMSP::dx(GRID, 2));
 		#if VTK_MAJOR_VERSION <= 5
-		vtkData->SetScalarTypeToDouble();
-		vtkData->SetNumberOfScalarComponents(1);
+		scalarData->SetScalarTypeToDouble();
+		scalarData->SetNumberOfScalarComponents(1);
 		#else
-		vtkData->AllocateScalars(VTK_DOUBLE, 1);
+		scalarData->AllocateScalars(VTK_DOUBLE, 1);
 		#endif
 
 		MMSP::vector<int> x(3,0);
 		for (x[2]=MMSP::z0(GRID); x[2]<MMSP::z1(GRID); x[2]++) {
 			for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
 				for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
-					double* pixel = static_cast<double*>(vtkData->GetScalarPointer(x[0], x[1], x[2]));
+					double* pixel = static_cast<double*>(scalarData->GetScalarPointer(x[0], x[1], x[2]));
 					if (mode==1) { // --mag
-						pixel[0] = std::sqrt(GRID(x)*GRID(x));
+						*pixel = std::sqrt(GRID(x)*GRID(x));
 					} else {
-						pixel[0] = GRID(x);
+						*pixel = GRID(x);
 					}
 				}
 			}
 		}
 	}
-	vtkData->GetPointData()->GetAbstractArray(0)->SetName("scalar_data");
+	scalarData->GetPointData()->GetAbstractArray(0)->SetName("scalar_data");
 
 	vtkSmartPointer<vtkXMLImageDataWriter> writer = vtkSmartPointer<vtkXMLImageDataWriter>::New();
 	writer->SetFileName(filename.c_str());
 	#if VTK_MAJOR_VERSION <= 5
-	writer->SetInputConnection(vtkData->GetProducerPort());
+	writer->SetInputConnection(scalarData->GetProducerPort());
 	#else
-	writer->SetInputData(vtkData);
+	writer->SetInputData(scalarData);
 	#endif
 	writer->Write();
 
-	vtkData = NULL;
+	scalarData = NULL;
 	writer = NULL;
 }
 
 template<int dim, typename T> void print_vectors(std::string filename, const MMSP::grid<dim,MMSP::vector<T> >& GRID,
         const int mode, const int field)
 {
-	vtkSmartPointer<vtkImageData> vtkData = vtkSmartPointer<vtkImageData>::New();
+	vtkSmartPointer<vtkImageData> vectorData = vtkSmartPointer<vtkImageData>::New();
 
 	if (dim==1) {
-		vtkData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID), 1, 1);
-		vtkData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1, 0, 0, 0, 0);
-		vtkData->SetSpacing(MMSP::dx(GRID), 1, 1);
+		vectorData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID), 1, 1);
+		vectorData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1, 0, 0, 0, 0);
+		vectorData->SetSpacing(MMSP::dx(GRID), 1, 1);
 		#if VTK_MAJOR_VERSION <= 5
-		vtkData->SetScalarTypeToDouble();
+		vectorData->SetScalarTypeToDouble();
 		if (mode==1 || mode==2 || mode==3)
-			vtkData->SetNumberOfScalarComponents(1);
+			vectorData->SetNumberOfScalarComponents(1);
 		else
-			vtkData->SetNumberOfScalarComponents(MMSP::fields(GRID));
+			vectorData->SetNumberOfScalarComponents(MMSP::fields(GRID));
 		#else
 		if (mode==1 || mode==2 || mode==3)
-			vtkData->AllocateScalars(VTK_DOUBLE, 1);
+			vectorData->AllocateScalars(VTK_DOUBLE, 1);
 		else
-			vtkData->AllocateScalars(VTK_DOUBLE, MMSP::fields(GRID));
+			vectorData->AllocateScalars(VTK_DOUBLE, MMSP::fields(GRID));
 		#endif
 
 		MMSP::vector<int> x(1,0);
 		for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
 			const MMSP::vector<T>& v = GRID(x);
-			double* pixel = static_cast<double*>(vtkData->GetScalarPointer(x[0], 0, 0));
+			double* pixel = static_cast<double*>(vectorData->GetScalarPointer(x[0], 0, 0));
 			if (mode==1) { // --mag
 				double sum = 0.0;
 				for (int h = 0; h < v.length(); h++)
 					sum += v[h]*v[h];
-				pixel[0] = std::sqrt(sum);
+				*pixel = std::sqrt(sum);
 			} else if (mode==2) { // --max
 				// Export index of field with greatest magnitude
 				int max = 0;
 				for (int h = 1; h < v.length(); h++)
 					if (v[h] > v[max])
 						max = h;
-				pixel[0] = max;
+				*pixel = max;
 			} else if (mode==3) { // --field
-				pixel[0] = v[field];
+				*pixel = v[field];
 			} else {
 				for (int h = 0; h < v.length(); h++)
 					pixel[h] = v[h];
 			}
 		}
 	} else if (dim==2) {
-		vtkData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID),
+		vectorData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID),
 		                       MMSP::y1(GRID)-MMSP::y0(GRID),
 		                       1);
-		vtkData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1,
+		vectorData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1,
 		                   MMSP::y0(GRID), MMSP::y1(GRID) - 1,
 		                   0, 0);
-		vtkData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), 1);
+		vectorData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), 1);
 		#if VTK_MAJOR_VERSION <= 5
-		vtkData->SetScalarTypeToDouble();
+		vectorData->SetScalarTypeToDouble();
 		if (mode==1 || mode==2 || mode==3)
-			vtkData->SetNumberOfScalarComponents(1);
+			vectorData->SetNumberOfScalarComponents(1);
 		else
-			vtkData->SetNumberOfScalarComponents(MMSP::fields(GRID));
+			vectorData->SetNumberOfScalarComponents(MMSP::fields(GRID));
 		#else
 		if (mode==1 || mode==2 || mode==3)
-			vtkData->AllocateScalars(VTK_DOUBLE, 1);
+			vectorData->AllocateScalars(VTK_DOUBLE, 1);
 		else
-			vtkData->AllocateScalars(VTK_DOUBLE, MMSP::fields(GRID));
+			vectorData->AllocateScalars(VTK_DOUBLE, MMSP::fields(GRID));
 		#endif
 
 		MMSP::vector<int> x(2,0);
 		for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
 			for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
 				const MMSP::vector<T>& v = GRID(x);
-				double* pixel = static_cast<double*>(vtkData->GetScalarPointer(x[0], x[1], 0));
+				double* pixel = static_cast<double*>(vectorData->GetScalarPointer(x[0], x[1], 0));
 				if (mode==1) { // --mag
 					double sum = 0.0;
 					for (int h = 0; h < v.length(); h++)
 						sum += v[h]*v[h];
-					pixel[0] = std::sqrt(sum);
+					*pixel = std::sqrt(sum);
 				} else if (mode==2) { // --max
 					// Export index of field with greatest magnitude
 					int max = 0;
 					for (int h = 1; h < v.length(); h++)
 						if (v[h] > v[max])
 							max = h;
-					pixel[0] = max;
+					*pixel = max;
 				} else if (mode==3) { // --field
-					pixel[0] = v[field];
+					*pixel = v[field];
 				} else {
 					for (int h = 0; h < v.length(); h++)
 						pixel[h] = v[h];
@@ -198,24 +198,24 @@ template<int dim, typename T> void print_vectors(std::string filename, const MMS
 			}
 		}
 	} else if (dim==3) {
-		vtkData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID),
+		vectorData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID),
 		                       MMSP::y1(GRID)-MMSP::y0(GRID),
 		                       MMSP::z1(GRID)-MMSP::z0(GRID));
-		vtkData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1,
+		vectorData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1,
 		                   MMSP::y0(GRID), MMSP::y1(GRID) - 1,
 		                   MMSP::z0(GRID), MMSP::z1(GRID) - 1);
-		vtkData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), MMSP::dx(GRID, 2));
+		vectorData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), MMSP::dx(GRID, 2));
 		#if VTK_MAJOR_VERSION <= 5
-		vtkData->SetScalarTypeToDouble();
+		vectorData->SetScalarTypeToDouble();
 		if (mode==1 || mode==2 || mode==3)
-			vtkData->SetNumberOfScalarComponents(1);
+			vectorData->SetNumberOfScalarComponents(1);
 		else
-			vtkData->SetNumberOfScalarComponents(MMSP::fields(GRID));
+			vectorData->SetNumberOfScalarComponents(MMSP::fields(GRID));
 		#else
 		if (mode==1 || mode==2 || mode==3)
-			vtkData->AllocateScalars(VTK_DOUBLE, 1);
+			vectorData->AllocateScalars(VTK_DOUBLE, 1);
 		else
-			vtkData->AllocateScalars(VTK_DOUBLE, MMSP::fields(GRID));
+			vectorData->AllocateScalars(VTK_DOUBLE, MMSP::fields(GRID));
 		#endif
 
 		MMSP::vector<int> x(3,0);
@@ -223,21 +223,21 @@ template<int dim, typename T> void print_vectors(std::string filename, const MMS
 			for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
 				for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
 					const MMSP::vector<T>& v = GRID(x);
-					double* pixel = static_cast<double*>(vtkData->GetScalarPointer(x[0], x[1], x[2]));
+					double* pixel = static_cast<double*>(vectorData->GetScalarPointer(x[0], x[1], x[2]));
 					if (mode==1) { // --mag
 						double sum = 0.0;
 						for (int h = 0; h < v.length(); h++)
 							sum += v[h]*v[h];
-						pixel[0] = std::sqrt(sum);
+						*pixel = std::sqrt(sum);
 					} else if (mode==2) { // --max
 						// Export index of field with greatest magnitude
 						int max = 0;
 						for (int h = 1; h < v.length(); h++)
 							if (v[h] > v[max])
 								max = h;
-						pixel[0] = max;
+						*pixel = max;
 					} else if (mode==3) { // --field
-						pixel[0] = v[field];
+						*pixel = v[field];
 					} else {
 						for (int h = 0; h < v.length(); h++)
 							pixel[h] = v[h];
@@ -246,108 +246,108 @@ template<int dim, typename T> void print_vectors(std::string filename, const MMS
 			}
 		}
 	}
-	vtkData->GetPointData()->GetAbstractArray(0)->SetName("vector_data");
+	vectorData->GetPointData()->GetAbstractArray(0)->SetName("vector_data");
 
 	vtkSmartPointer<vtkXMLImageDataWriter> writer = vtkSmartPointer<vtkXMLImageDataWriter>::New();
 	writer->SetFileName(filename.c_str());
 	#if VTK_MAJOR_VERSION <= 5
-	writer->SetInputConnection(vtkData->GetProducerPort());
+	writer->SetInputConnection(vectorData->GetProducerPort());
 	#else
-	writer->SetInputData(vtkData);
+	writer->SetInputData(vectorData);
 	#endif
 
 	writer->Write();
 
-	vtkData = NULL;
+	vectorData = NULL;
 	writer = NULL;
 }
 
 template<int dim, typename T> void print_sparses(std::string filename, const MMSP::grid<dim,MMSP::sparse<T> >& GRID,
         const int mode, const int field)
 {
-	vtkSmartPointer<vtkImageData> vtkData = vtkSmartPointer<vtkImageData>::New();
+	vtkSmartPointer<vtkImageData> sparseData = vtkSmartPointer<vtkImageData>::New();
 
 	if (dim==1) {
-		vtkData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID), 1, 1);
-		vtkData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1, 0, 0, 0, 0);
-		vtkData->SetSpacing(MMSP::dx(GRID, 0), 1, 1);
+		sparseData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID), 1, 1);
+		sparseData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1, 0, 0, 0, 0);
+		sparseData->SetSpacing(MMSP::dx(GRID, 0), 1, 1);
 		#if VTK_MAJOR_VERSION <= 5
-		vtkData->SetNumberOfScalarComponents(1);
-		vtkData->SetScalarTypeToDouble();
+		sparseData->SetNumberOfScalarComponents(1);
+		sparseData->SetScalarTypeToDouble();
 		#else
-		vtkData->AllocateScalars(VTK_DOUBLE, 1);
+		sparseData->AllocateScalars(VTK_DOUBLE, 1);
 		#endif
 
 		MMSP::vector<int> x(1,0);
 		for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
 			const MMSP::sparse<T>& s = GRID(x);
-			double* pixel = static_cast<double*>(vtkData->GetScalarPointer(x[0], 0, 0));
+			double* pixel = static_cast<double*>(sparseData->GetScalarPointer(x[0], 0, 0));
 			if (mode==2) { // --max
 				// Export index of field with greatest magnitude
 				int max = 0;
 				for (int h = 1; h < s.length(); h++)
 					if (s.value(h) > s.value(max))
 						max = h;
-				pixel[0] =  s.index(max);
+				*pixel =  s.index(max);
 			} else if (mode==3) { // --field
-				pixel[0] = s[field];
+				*pixel = s[field];
 			} else { // --mag is redundant for sparse
 				double sum = 0.0;
 				for (int h = 0; h < s.length(); h++)
 					sum += s.value(h)*s.value(h);
-				pixel[0] = std::sqrt(sum);
+				*pixel = std::sqrt(sum);
 			}
 		}
 	} else if (dim==2) {
-		vtkData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID),
+		sparseData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID),
 		                       MMSP::y1(GRID)-MMSP::y0(GRID),
 		                       1);
-		vtkData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1,
+		sparseData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1,
 		                   MMSP::y0(GRID), MMSP::y1(GRID) - 1,
 		                   0, 0);
-		vtkData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), 1);
+		sparseData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), 1);
 		#if VTK_MAJOR_VERSION <= 5
-		vtkData->SetNumberOfScalarComponents(1);
-		vtkData->SetScalarTypeToDouble();
+		sparseData->SetNumberOfScalarComponents(1);
+		sparseData->SetScalarTypeToDouble();
 		#else
-		vtkData->AllocateScalars(VTK_DOUBLE, 1);
+		sparseData->AllocateScalars(VTK_DOUBLE, 1);
 		#endif
 
 		MMSP::vector<int> x(2,0);
 		for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
 			for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
 				const MMSP::sparse<T>& s = GRID(x);
-				double* pixel = static_cast<double*>(vtkData->GetScalarPointer(x[0], x[1], 0));
+				double* pixel = static_cast<double*>(sparseData->GetScalarPointer(x[0], x[1], 0));
 				if (mode==2) { // --max
 					// Export index of field with greatest magnitude
 					int max = 0;
 					for (int h = 1; h < s.length(); h++)
 						if (s.value(h) > s.value(max))
 							max = h;
-					pixel[0] =  s.index(max);
+					*pixel =  s.index(max);
 				} else if (mode==3) { // --field
-					pixel[0] = s[field];
+					*pixel = s[field];
 				} else { // --mag is redundant for sparse
 					double sum = 0.0;
 					for (int h = 0; h < s.length(); h++)
 						sum += s.value(h)*s.value(h);
-					pixel[0] = std::sqrt(sum);
+					*pixel = std::sqrt(sum);
 				}
 			}
 		}
 	} else if (dim==3) {
-		vtkData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID),
+		sparseData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID),
 		                       MMSP::y1(GRID)-MMSP::y0(GRID),
 		                       MMSP::z1(GRID)-MMSP::z0(GRID));
-		vtkData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1,
+		sparseData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1,
 		                   MMSP::y0(GRID), MMSP::y1(GRID) - 1,
 		                   MMSP::z0(GRID), MMSP::z1(GRID) - 1);
-		vtkData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), MMSP::dx(GRID, 2));
+		sparseData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), MMSP::dx(GRID, 2));
 		#if VTK_MAJOR_VERSION <= 5
-		vtkData->SetNumberOfScalarComponents(1);
-		vtkData->SetScalarTypeToDouble();
+		sparseData->SetNumberOfScalarComponents(1);
+		sparseData->SetScalarTypeToDouble();
 		#else
-		vtkData->AllocateScalars(VTK_DOUBLE, 1);
+		sparseData->AllocateScalars(VTK_DOUBLE, 1);
 		#endif
 
 		MMSP::vector<int> x(3,0);
@@ -355,38 +355,38 @@ template<int dim, typename T> void print_sparses(std::string filename, const MMS
 			for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
 				for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
 					const MMSP::sparse<T>& s = GRID(x);
-					double* pixel = static_cast<double*>(vtkData->GetScalarPointer(x[0], x[1], x[2]));
+					double* pixel = static_cast<double*>(sparseData->GetScalarPointer(x[0], x[1], x[2]));
 					if (mode==2) { // --max
 						// Export index of field with greatest magnitude
 						int max = 0;
 						for (int h = 1; h < s.length(); h++)
 							if (s.value(h) > s.value(max))
 								max = h;
-						pixel[0] =  s.index(max);
+						*pixel =  s.index(max);
 					} else if (mode==3) { // --field
-						pixel[0] = s[field];
+						*pixel = s[field];
 					} else { // --mag is redundant for sparse
 						double sum = 0.0;
 						for (int h = 0; h < s.length(); h++)
 							sum += s.value(h)*s.value(h);
-						pixel[0] = std::sqrt(sum);
+						*pixel = std::sqrt(sum);
 					}
 				}
 			}
 		}
 	}
-	vtkData->GetPointData()->GetAbstractArray(0)->SetName("sparse_data");
+	sparseData->GetPointData()->GetAbstractArray(0)->SetName("sparse_data");
 
 	vtkSmartPointer<vtkXMLImageDataWriter> writer = vtkSmartPointer<vtkXMLImageDataWriter>::New();
 	writer->SetFileName(filename.c_str());
 	#if VTK_MAJOR_VERSION <= 5
-	writer->SetInputConnection(vtkData->GetProducerPort());
+	writer->SetInputConnection(sparseData->GetProducerPort());
 	#else
-	writer->SetInputData(vtkData);
+	writer->SetInputData(sparseData);
 	#endif
 	writer->Write();
 
-	vtkData = NULL;
+	sparseData = NULL;
 	writer = NULL;
 }
 

--- a/utility/mmsp2vti.cpp
+++ b/utility/mmsp2vti.cpp
@@ -21,15 +21,15 @@ template<int dim, typename T> void print_scalars(std::string filename, const MMS
 		scalarData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1, 0, 0, 0, 0);
 		scalarData->SetSpacing(MMSP::dx(GRID), 1, 1);
 		#if VTK_MAJOR_VERSION <= 5
-		scalarData->SetScalarTypeToDouble();
+		scalarData->SetScalarTypeToFloat();
 		scalarData->SetNumberOfScalarComponents(1);
 		#else
-		scalarData->AllocateScalars(VTK_DOUBLE, 1);
+		scalarData->AllocateScalars(VTK_FLOAT, 1);
 		#endif
 
 		MMSP::vector<int> x(1,0);
 		for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
-			double* pixel = static_cast<double*>(scalarData->GetScalarPointer(x[0], 0, 0));
+			float* pixel = static_cast<float*>(scalarData->GetScalarPointer(x[0], 0, 0));
 			if (mode==1) { // --mag
 				*pixel = std::sqrt(GRID(x)*GRID(x));
 			} else {
@@ -45,16 +45,16 @@ template<int dim, typename T> void print_scalars(std::string filename, const MMS
 		                   0, 0);
 		scalarData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), 1);
 		#if VTK_MAJOR_VERSION <= 5
-		scalarData->SetScalarTypeToDouble();
+		scalarData->SetScalarTypeToFloat();
 		scalarData->SetNumberOfScalarComponents(1);
 		#else
-		scalarData->AllocateScalars(VTK_DOUBLE, 1);
+		scalarData->AllocateScalars(VTK_FLOAT, 1);
 		#endif
 
 		MMSP::vector<int> x(2,0);
 		for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
 			for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
-				double* pixel = static_cast<double*>(scalarData->GetScalarPointer(x[0], x[1], 0));
+				float* pixel = static_cast<float*>(scalarData->GetScalarPointer(x[0], x[1], 0));
 				if (mode==1) { // --mag
 					*pixel = std::sqrt(GRID(x)*GRID(x));
 				} else {
@@ -71,17 +71,17 @@ template<int dim, typename T> void print_scalars(std::string filename, const MMS
 		                   MMSP::z0(GRID), MMSP::z1(GRID) - 1);
 		scalarData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), MMSP::dx(GRID, 2));
 		#if VTK_MAJOR_VERSION <= 5
-		scalarData->SetScalarTypeToDouble();
+		scalarData->SetScalarTypeToFloat();
 		scalarData->SetNumberOfScalarComponents(1);
 		#else
-		scalarData->AllocateScalars(VTK_DOUBLE, 1);
+		scalarData->AllocateScalars(VTK_FLOAT, 1);
 		#endif
 
 		MMSP::vector<int> x(3,0);
 		for (x[2]=MMSP::z0(GRID); x[2]<MMSP::z1(GRID); x[2]++) {
 			for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
 				for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
-					double* pixel = static_cast<double*>(scalarData->GetScalarPointer(x[0], x[1], x[2]));
+					float* pixel = static_cast<float*>(scalarData->GetScalarPointer(x[0], x[1], x[2]));
 					if (mode==1) { // --mag
 						*pixel = std::sqrt(GRID(x)*GRID(x));
 					} else {
@@ -116,22 +116,22 @@ template<int dim, typename T> void print_vectors(std::string filename, const MMS
 		vectorData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1, 0, 0, 0, 0);
 		vectorData->SetSpacing(MMSP::dx(GRID), 1, 1);
 		#if VTK_MAJOR_VERSION <= 5
-		vectorData->SetScalarTypeToDouble();
+		vectorData->SetScalarTypeToFloat();
 		if (mode==1 || mode==2 || mode==3)
 			vectorData->SetNumberOfScalarComponents(1);
 		else
 			vectorData->SetNumberOfScalarComponents(MMSP::fields(GRID));
 		#else
 		if (mode==1 || mode==2 || mode==3)
-			vectorData->AllocateScalars(VTK_DOUBLE, 1);
+			vectorData->AllocateScalars(VTK_FLOAT, 1);
 		else
-			vectorData->AllocateScalars(VTK_DOUBLE, MMSP::fields(GRID));
+			vectorData->AllocateScalars(VTK_FLOAT, MMSP::fields(GRID));
 		#endif
 
 		MMSP::vector<int> x(1,0);
 		for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
 			const MMSP::vector<T>& v = GRID(x);
-			double* pixel = static_cast<double*>(vectorData->GetScalarPointer(x[0], 0, 0));
+			float* pixel = static_cast<float*>(vectorData->GetScalarPointer(x[0], 0, 0));
 			if (mode==1) { // --mag
 				double sum = 0.0;
 				for (int h = 0; h < v.length(); h++)
@@ -160,23 +160,23 @@ template<int dim, typename T> void print_vectors(std::string filename, const MMS
 		                   0, 0);
 		vectorData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), 1);
 		#if VTK_MAJOR_VERSION <= 5
-		vectorData->SetScalarTypeToDouble();
+		vectorData->SetScalarTypeToFloat();
 		if (mode==1 || mode==2 || mode==3)
 			vectorData->SetNumberOfScalarComponents(1);
 		else
 			vectorData->SetNumberOfScalarComponents(MMSP::fields(GRID));
 		#else
 		if (mode==1 || mode==2 || mode==3)
-			vectorData->AllocateScalars(VTK_DOUBLE, 1);
+			vectorData->AllocateScalars(VTK_FLOAT, 1);
 		else
-			vectorData->AllocateScalars(VTK_DOUBLE, MMSP::fields(GRID));
+			vectorData->AllocateScalars(VTK_FLOAT, MMSP::fields(GRID));
 		#endif
 
 		MMSP::vector<int> x(2,0);
 		for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
 			for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
 				const MMSP::vector<T>& v = GRID(x);
-				double* pixel = static_cast<double*>(vectorData->GetScalarPointer(x[0], x[1], 0));
+				float* pixel = static_cast<float*>(vectorData->GetScalarPointer(x[0], x[1], 0));
 				if (mode==1) { // --mag
 					double sum = 0.0;
 					for (int h = 0; h < v.length(); h++)
@@ -206,16 +206,16 @@ template<int dim, typename T> void print_vectors(std::string filename, const MMS
 		                   MMSP::z0(GRID), MMSP::z1(GRID) - 1);
 		vectorData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), MMSP::dx(GRID, 2));
 		#if VTK_MAJOR_VERSION <= 5
-		vectorData->SetScalarTypeToDouble();
+		vectorData->SetScalarTypeToFloat();
 		if (mode==1 || mode==2 || mode==3)
 			vectorData->SetNumberOfScalarComponents(1);
 		else
 			vectorData->SetNumberOfScalarComponents(MMSP::fields(GRID));
 		#else
 		if (mode==1 || mode==2 || mode==3)
-			vectorData->AllocateScalars(VTK_DOUBLE, 1);
+			vectorData->AllocateScalars(VTK_FLOAT, 1);
 		else
-			vectorData->AllocateScalars(VTK_DOUBLE, MMSP::fields(GRID));
+			vectorData->AllocateScalars(VTK_FLOAT, MMSP::fields(GRID));
 		#endif
 
 		MMSP::vector<int> x(3,0);
@@ -223,7 +223,7 @@ template<int dim, typename T> void print_vectors(std::string filename, const MMS
 			for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
 				for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
 					const MMSP::vector<T>& v = GRID(x);
-					double* pixel = static_cast<double*>(vectorData->GetScalarPointer(x[0], x[1], x[2]));
+					float* pixel = static_cast<float*>(vectorData->GetScalarPointer(x[0], x[1], x[2]));
 					if (mode==1) { // --mag
 						double sum = 0.0;
 						for (int h = 0; h < v.length(); h++)
@@ -273,15 +273,15 @@ template<int dim, typename T> void print_sparses(std::string filename, const MMS
 		sparseData->SetSpacing(MMSP::dx(GRID, 0), 1, 1);
 		#if VTK_MAJOR_VERSION <= 5
 		sparseData->SetNumberOfScalarComponents(1);
-		sparseData->SetScalarTypeToDouble();
+		sparseData->SetScalarTypeToFloat();
 		#else
-		sparseData->AllocateScalars(VTK_DOUBLE, 1);
+		sparseData->AllocateScalars(VTK_FLOAT, 1);
 		#endif
 
 		MMSP::vector<int> x(1,0);
 		for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
 			const MMSP::sparse<T>& s = GRID(x);
-			double* pixel = static_cast<double*>(sparseData->GetScalarPointer(x[0], 0, 0));
+			float* pixel = static_cast<float*>(sparseData->GetScalarPointer(x[0], 0, 0));
 			if (mode==2) { // --max
 				// Export index of field with greatest magnitude
 				int max = 0;
@@ -308,16 +308,16 @@ template<int dim, typename T> void print_sparses(std::string filename, const MMS
 		sparseData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), 1);
 		#if VTK_MAJOR_VERSION <= 5
 		sparseData->SetNumberOfScalarComponents(1);
-		sparseData->SetScalarTypeToDouble();
+		sparseData->SetScalarTypeToFloat();
 		#else
-		sparseData->AllocateScalars(VTK_DOUBLE, 1);
+		sparseData->AllocateScalars(VTK_FLOAT, 1);
 		#endif
 
 		MMSP::vector<int> x(2,0);
 		for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
 			for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
 				const MMSP::sparse<T>& s = GRID(x);
-				double* pixel = static_cast<double*>(sparseData->GetScalarPointer(x[0], x[1], 0));
+				float* pixel = static_cast<float*>(sparseData->GetScalarPointer(x[0], x[1], 0));
 				if (mode==2) { // --max
 					// Export index of field with greatest magnitude
 					int max = 0;
@@ -345,9 +345,9 @@ template<int dim, typename T> void print_sparses(std::string filename, const MMS
 		sparseData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), MMSP::dx(GRID, 2));
 		#if VTK_MAJOR_VERSION <= 5
 		sparseData->SetNumberOfScalarComponents(1);
-		sparseData->SetScalarTypeToDouble();
+		sparseData->SetScalarTypeToFloat();
 		#else
-		sparseData->AllocateScalars(VTK_DOUBLE, 1);
+		sparseData->AllocateScalars(VTK_FLOAT, 1);
 		#endif
 
 		MMSP::vector<int> x(3,0);
@@ -355,7 +355,7 @@ template<int dim, typename T> void print_sparses(std::string filename, const MMS
 			for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
 				for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
 					const MMSP::sparse<T>& s = GRID(x);
-					double* pixel = static_cast<double*>(sparseData->GetScalarPointer(x[0], x[1], x[2]));
+					float* pixel = static_cast<float*>(sparseData->GetScalarPointer(x[0], x[1], x[2]));
 					if (mode==2) { // --max
 						// Export index of field with greatest magnitude
 						int max = 0;

--- a/utility/mmsp2vti.cpp
+++ b/utility/mmsp2vti.cpp
@@ -6,27 +6,27 @@
 #include <fstream>
 #include <string>
 #include <vtkImageData.h>
-#include <vtkInformation.h>
 #include <vtkPointData.h>
-#include <vtkProperty.h>
 #include <vtkSmartPointer.h>
 #include <vtkVersion.h>
 #include <vtkXMLImageDataWriter.h>
-#include <vtkXMLWriter.h>
 #include "MMSP.hpp"
 
 template<int dim, typename T> void print_scalars(std::string filename, const MMSP::grid<dim,T>& GRID, const int mode)
 {
 	vtkSmartPointer<vtkImageData> vtkData = vtkSmartPointer<vtkImageData>::New();
-	vtkData->SetDimensions(MMSP::xlength(GRID, 0), MMSP::xlength(GRID, 1), MMSP::xlength(GRID, 2));
-	#if VTK_MAJOR_VERSION <= 5
-	vtkData->SetNumberOfScalarComponents(1);
-	vtkData->SetScalarTypeToDouble();
-	#else
-	vtkData->AllocateScalars(VTK_DOUBLE, 1);
-	#endif
 
 	if (dim==1) {
+		vtkData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID), 1, 1);
+		vtkData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1, 0, 0, 0, 0);
+		vtkData->SetSpacing(MMSP::dx(GRID), 1, 1);
+		#if VTK_MAJOR_VERSION <= 5
+		vtkData->SetScalarTypeToDouble();
+		vtkData->SetNumberOfScalarComponents(1);
+		#else
+		vtkData->AllocateScalars(VTK_DOUBLE, 1);
+		#endif
+
 		MMSP::vector<int> x(1,0);
 		for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
 			double* pixel = static_cast<double*>(vtkData->GetScalarPointer(x[0], 0, 0));
@@ -37,6 +37,20 @@ template<int dim, typename T> void print_scalars(std::string filename, const MMS
 			}
 		}
 	} else if (dim==2) {
+		vtkData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID),
+		                       MMSP::y1(GRID)-MMSP::y0(GRID),
+		                       1);
+		vtkData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1,
+		                   MMSP::y0(GRID), MMSP::y1(GRID) - 1,
+		                   0, 0);
+		vtkData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), 1);
+		#if VTK_MAJOR_VERSION <= 5
+		vtkData->SetScalarTypeToDouble();
+		vtkData->SetNumberOfScalarComponents(1);
+		#else
+		vtkData->AllocateScalars(VTK_DOUBLE, 1);
+		#endif
+
 		MMSP::vector<int> x(2,0);
 		for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
 			for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
@@ -49,6 +63,20 @@ template<int dim, typename T> void print_scalars(std::string filename, const MMS
 			}
 		}
 	} else if (dim==3) {
+		vtkData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID),
+		                       MMSP::y1(GRID)-MMSP::y0(GRID),
+		                       MMSP::z1(GRID)-MMSP::z0(GRID));
+		vtkData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1,
+		                   MMSP::y0(GRID), MMSP::y1(GRID) - 1,
+		                   MMSP::z0(GRID), MMSP::z1(GRID) - 1);
+		vtkData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), MMSP::dx(GRID, 2));
+		#if VTK_MAJOR_VERSION <= 5
+		vtkData->SetScalarTypeToDouble();
+		vtkData->SetNumberOfScalarComponents(1);
+		#else
+		vtkData->AllocateScalars(VTK_DOUBLE, 1);
+		#endif
+
 		MMSP::vector<int> x(3,0);
 		for (x[2]=MMSP::z0(GRID); x[2]<MMSP::z1(GRID); x[2]++) {
 			for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
@@ -63,10 +91,10 @@ template<int dim, typename T> void print_scalars(std::string filename, const MMS
 			}
 		}
 	}
+	vtkData->GetPointData()->GetAbstractArray(0)->SetName("scalar_data");
 
 	vtkSmartPointer<vtkXMLImageDataWriter> writer = vtkSmartPointer<vtkXMLImageDataWriter>::New();
 	writer->SetFileName(filename.c_str());
-	writer->SetCompressorTypeToZLib();
 	#if VTK_MAJOR_VERSION <= 5
 	writer->SetInputConnection(vtkData->GetProducerPort());
 	#else
@@ -82,15 +110,13 @@ template<int dim, typename T> void print_vectors(std::string filename, const MMS
         const int mode, const int field)
 {
 	vtkSmartPointer<vtkImageData> vtkData = vtkSmartPointer<vtkImageData>::New();
-	#if VTK_MAJOR_VERSION <= 5
-	vtkData->SetScalarTypeToDouble();
-	#endif
 
 	if (dim==1) {
 		vtkData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID), 1, 1);
-	    vtkData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1, 0, 0, 0, 0);
+		vtkData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1, 0, 0, 0, 0);
 		vtkData->SetSpacing(MMSP::dx(GRID), 1, 1);
 		#if VTK_MAJOR_VERSION <= 5
+		vtkData->SetScalarTypeToDouble();
 		if (mode==1 || mode==2 || mode==3)
 			vtkData->SetNumberOfScalarComponents(1);
 		else
@@ -126,10 +152,15 @@ template<int dim, typename T> void print_vectors(std::string filename, const MMS
 			}
 		}
 	} else if (dim==2) {
-		vtkData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID), MMSP::y1(GRID)-MMSP::y0(GRID), 1);
-		vtkData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1, MMSP::y0(GRID), MMSP::y1(GRID) - 1, 0, 0);
+		vtkData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID),
+		                       MMSP::y1(GRID)-MMSP::y0(GRID),
+		                       1);
+		vtkData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1,
+		                   MMSP::y0(GRID), MMSP::y1(GRID) - 1,
+		                   0, 0);
 		vtkData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), 1);
 		#if VTK_MAJOR_VERSION <= 5
+		vtkData->SetScalarTypeToDouble();
 		if (mode==1 || mode==2 || mode==3)
 			vtkData->SetNumberOfScalarComponents(1);
 		else
@@ -167,10 +198,15 @@ template<int dim, typename T> void print_vectors(std::string filename, const MMS
 			}
 		}
 	} else if (dim==3) {
-		vtkData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID), MMSP::y1(GRID)-MMSP::y0(GRID), MMSP::z1(GRID)-MMSP::z0(GRID));
-		vtkData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1, MMSP::y0(GRID), MMSP::y1(GRID) - 1, MMSP::z0(GRID), MMSP::z1(GRID) - 1);
+		vtkData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID),
+		                       MMSP::y1(GRID)-MMSP::y0(GRID),
+		                       MMSP::z1(GRID)-MMSP::z0(GRID));
+		vtkData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1,
+		                   MMSP::y0(GRID), MMSP::y1(GRID) - 1,
+		                   MMSP::z0(GRID), MMSP::z1(GRID) - 1);
 		vtkData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), MMSP::dx(GRID, 2));
 		#if VTK_MAJOR_VERSION <= 5
+		vtkData->SetScalarTypeToDouble();
 		if (mode==1 || mode==2 || mode==3)
 			vtkData->SetNumberOfScalarComponents(1);
 		else
@@ -214,12 +250,12 @@ template<int dim, typename T> void print_vectors(std::string filename, const MMS
 
 	vtkSmartPointer<vtkXMLImageDataWriter> writer = vtkSmartPointer<vtkXMLImageDataWriter>::New();
 	writer->SetFileName(filename.c_str());
-	writer->SetCompressorTypeToZLib();
 	#if VTK_MAJOR_VERSION <= 5
 	writer->SetInputConnection(vtkData->GetProducerPort());
 	#else
 	writer->SetInputData(vtkData);
 	#endif
+
 	writer->Write();
 
 	vtkData = NULL;
@@ -230,15 +266,18 @@ template<int dim, typename T> void print_sparses(std::string filename, const MMS
         const int mode, const int field)
 {
 	vtkSmartPointer<vtkImageData> vtkData = vtkSmartPointer<vtkImageData>::New();
-	vtkData->SetDimensions(MMSP::xlength(GRID, 0), MMSP::xlength(GRID, 1), MMSP::xlength(GRID, 2));
-	#if VTK_MAJOR_VERSION <= 5
-	vtkData->SetNumberOfScalarComponents(1);
-	vtkData->SetScalarTypeToDouble();
-	#else
-	vtkData->AllocateScalars(VTK_DOUBLE, 1);
-	#endif
 
 	if (dim==1) {
+		vtkData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID), 1, 1);
+		vtkData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1, 0, 0, 0, 0);
+		vtkData->SetSpacing(MMSP::dx(GRID, 0), 1, 1);
+		#if VTK_MAJOR_VERSION <= 5
+		vtkData->SetNumberOfScalarComponents(1);
+		vtkData->SetScalarTypeToDouble();
+		#else
+		vtkData->AllocateScalars(VTK_DOUBLE, 1);
+		#endif
+
 		MMSP::vector<int> x(1,0);
 		for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
 			const MMSP::sparse<T>& s = GRID(x);
@@ -260,6 +299,20 @@ template<int dim, typename T> void print_sparses(std::string filename, const MMS
 			}
 		}
 	} else if (dim==2) {
+		vtkData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID),
+		                       MMSP::y1(GRID)-MMSP::y0(GRID),
+		                       1);
+		vtkData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1,
+		                   MMSP::y0(GRID), MMSP::y1(GRID) - 1,
+		                   0, 0);
+		vtkData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), 1);
+		#if VTK_MAJOR_VERSION <= 5
+		vtkData->SetNumberOfScalarComponents(1);
+		vtkData->SetScalarTypeToDouble();
+		#else
+		vtkData->AllocateScalars(VTK_DOUBLE, 1);
+		#endif
+
 		MMSP::vector<int> x(2,0);
 		for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
 			for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
@@ -283,6 +336,20 @@ template<int dim, typename T> void print_sparses(std::string filename, const MMS
 			}
 		}
 	} else if (dim==3) {
+		vtkData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID),
+		                       MMSP::y1(GRID)-MMSP::y0(GRID),
+		                       MMSP::z1(GRID)-MMSP::z0(GRID));
+		vtkData->SetExtent(MMSP::x0(GRID), MMSP::x1(GRID) - 1,
+		                   MMSP::y0(GRID), MMSP::y1(GRID) - 1,
+		                   MMSP::z0(GRID), MMSP::z1(GRID) - 1);
+		vtkData->SetSpacing(MMSP::dx(GRID, 0), MMSP::dx(GRID, 1), MMSP::dx(GRID, 2));
+		#if VTK_MAJOR_VERSION <= 5
+		vtkData->SetNumberOfScalarComponents(1);
+		vtkData->SetScalarTypeToDouble();
+		#else
+		vtkData->AllocateScalars(VTK_DOUBLE, 1);
+		#endif
+
 		MMSP::vector<int> x(3,0);
 		for (x[2]=MMSP::z0(GRID); x[2]<MMSP::z1(GRID); x[2]++) {
 			for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
@@ -308,10 +375,10 @@ template<int dim, typename T> void print_sparses(std::string filename, const MMS
 			}
 		}
 	}
+	vtkData->GetPointData()->GetAbstractArray(0)->SetName("sparse_data");
 
 	vtkSmartPointer<vtkXMLImageDataWriter> writer = vtkSmartPointer<vtkXMLImageDataWriter>::New();
 	writer->SetFileName(filename.c_str());
-	writer->SetCompressorTypeToZLib();
 	#if VTK_MAJOR_VERSION <= 5
 	writer->SetInputConnection(vtkData->GetProducerPort());
 	#else

--- a/utility/mmsp2vti.cpp
+++ b/utility/mmsp2vti.cpp
@@ -1,33 +1,47 @@
 // mmsp2vti.cpp
-// Convert MMSP grid data to VTK image data format
+// Convert MMSP grid data to XML VTK image data format
 // Questions/comments to gruberja@gmail.com (Jason Gruber)
 
-#include<string>
-#include<sstream>
-#include<fstream>
-#include<cmath>
-#include"MMSP.hpp"
+#include <cmath>
+#include <fstream>
+#include <string>
+#include <vtkVersion.h>
+#include <vtkSmartPointer.h>
+#include <vtkProperty.h>
+#include <vtkXMLImageDataWriter.h>
+#include <vtkImageData.h>
+#include "MMSP.hpp"
 
-
-template<int dim, typename T> void print_scalars(std::ofstream& fstr, const MMSP::grid<dim,T>& GRID, const int& mode)
+template<int dim, typename T> void print_scalars(std::string filename, const MMSP::grid<dim,T>& GRID, const int mode)
 {
+	vtkSmartPointer<vtkImageData> imageData = vtkSmartPointer<vtkImageData>::New();
+	imageData->SetDimensions(MMSP::xlength(GRID, 0), MMSP::xlength(GRID, 1), MMSP::xlength(GRID, 2));
+	#if VTK_MAJOR_VERSION <= 5
+	imageData->SetNumberOfScalarComponents(1);
+	imageData->SetScalarTypeToDouble();
+	#else
+	imageData->AllocateScalars(VTK_DOUBLE, 1);
+	#endif
+
 	if (dim==1) {
 		MMSP::vector<int> x(1,0);
 		for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
+			double* pixel = static_cast<double*>(imageData->GetScalarPointer(x[0] - MMSP::x0(GRID), 0, 0));
 			if (mode==1) { // --mag
-				fstr << std::sqrt(GRID(x)*GRID(x)) << " ";
+				pixel[0] = std::sqrt(GRID(x)*GRID(x));
 			} else {
-				fstr << GRID(x) << " ";
+				pixel[0] = GRID(x);
 			}
 		}
 	} else if (dim==2) {
 		MMSP::vector<int> x(2,0);
 		for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
 			for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
+				double* pixel = static_cast<double*>(imageData->GetScalarPointer(x[0] - MMSP::x0(GRID), x[1] - MMSP::y0(GRID), 0));
 				if (mode==1) { // --mag
-					fstr << std::sqrt(GRID(x)*GRID(x)) << " ";
+					pixel[0] = std::sqrt(GRID(x)*GRID(x));
 				} else {
-					fstr << GRID(x) << " ";
+					pixel[0] = GRID(x);
 				}
 			}
 		}
@@ -36,119 +50,197 @@ template<int dim, typename T> void print_scalars(std::ofstream& fstr, const MMSP
 		for (x[2]=MMSP::z0(GRID); x[2]<MMSP::z1(GRID); x[2]++) {
 			for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
 				for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
+					double* pixel = static_cast<double*>(imageData->GetScalarPointer(x[0] - MMSP::x0(GRID), x[1] - MMSP::y0(GRID), x[2] - MMSP::z0(GRID)));
 					if (mode==1) { // --mag
-						fstr << std::sqrt(GRID(x)*GRID(x)) << " ";
+						pixel[0] = std::sqrt(GRID(x)*GRID(x));
 					} else {
-						fstr << GRID(x) << " ";
+						pixel[0] = GRID(x);
 					}
 				}
 			}
 		}
 	}
+
+	vtkSmartPointer<vtkXMLImageDataWriter> writer = vtkSmartPointer<vtkXMLImageDataWriter>::New();
+	writer->SetFileName(filename.c_str());
+	// writer->SetCompressorType(ZLIB);
+	#if VTK_MAJOR_VERSION <= 5
+	writer->SetInputConnection(imageData->GetProducerPort());
+	#else
+	writer->SetInputData(imageData);
+	#endif
+	writer->Write();
 }
 
-template<int dim, typename T> void print_vectors(std::ofstream& fstr, const MMSP::grid<dim,MMSP::vector<T> >& GRID,
-                                                const int& mode, const int& field)
+template<int dim, typename T> void print_vectors(std::string filename, const MMSP::grid<dim,MMSP::vector<T> >& GRID,
+        const int mode, const int field)
 {
+	vtkSmartPointer<vtkImageData> imageData = vtkSmartPointer<vtkImageData>::New();
+	#if VTK_MAJOR_VERSION <= 5
+	imageData->SetScalarTypeToDouble();
+	#endif
+
 	if (dim==1) {
+		imageData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID), 1, 1);
+		#if VTK_MAJOR_VERSION <= 5
+		if (mode==1 || mode==2 || mode==3)
+			imageData->SetNumberOfScalarComponents(1);
+		else
+			imageData->SetNumberOfScalarComponents(MMSP::fields(GRID));
+		#else
+		if (mode==1 || mode==2 || mode==3)
+			imageData->AllocateScalars(VTK_DOUBLE, 1);
+		else
+			imageData->AllocateScalars(VTK_DOUBLE, MMSP::fields(GRID));
+		#endif
+
 		MMSP::vector<int> x(1,0);
 		for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
 			const MMSP::vector<T>& v = GRID(x);
+			double* pixel = static_cast<double*>(imageData->GetScalarPointer(x[0] - MMSP::x0(GRID), 0, 0));
 			if (mode==1) { // --mag
 				double sum = 0.0;
 				for (int h = 0; h < v.length(); h++)
 					sum += v[h]*v[h];
-				fstr << std::sqrt(sum) << " ";
+				pixel[0] = std::sqrt(sum);
 			} else if (mode==2) { // --max
 				// Export index of field with greatest magnitude
 				int max = 0;
 				for (int h = 1; h < v.length(); h++)
 					if (v[h] > v[max])
 						max = h;
-				fstr << max << " ";
+				pixel[0] = max;
 			} else if (mode==3) { // --field
-				fstr << v[field] << " ";
+				pixel[0] = v[field];
 			} else {
 				for (int h = 0; h < v.length(); h++)
-					fstr << v[h] << " ";
+					pixel[h] = v[h];
 			}
 		}
 	} else if (dim==2) {
+		imageData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID), MMSP::y1(GRID)-MMSP::y0(GRID), 1);
+		#if VTK_MAJOR_VERSION <= 5
+		if (mode==1 || mode==2 || mode==3)
+			imageData->SetNumberOfScalarComponents(1);
+		else
+			imageData->SetNumberOfScalarComponents(MMSP::fields(GRID));
+		#else
+		if (mode==1 || mode==2 || mode==3)
+			imageData->AllocateScalars(VTK_DOUBLE, 1);
+		else
+			imageData->AllocateScalars(VTK_DOUBLE, MMSP::fields(GRID));
+		#endif
+
 		MMSP::vector<int> x(2,0);
 		for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
 			for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
 				const MMSP::vector<T>& v = GRID(x);
+				double* pixel = static_cast<double*>(imageData->GetScalarPointer(x[0] - MMSP::x0(GRID), x[1] - MMSP::y0(GRID), 0));
 				if (mode==1) { // --mag
 					double sum = 0.0;
 					for (int h = 0; h < v.length(); h++)
 						sum += v[h]*v[h];
-					fstr << std::sqrt(sum) << " ";
+					pixel[0] = std::sqrt(sum);
 				} else if (mode==2) { // --max
 					// Export index of field with greatest magnitude
 					int max = 0;
 					for (int h = 1; h < v.length(); h++)
 						if (v[h] > v[max])
 							max = h;
-					fstr << max << " ";
+					pixel[0] = max;
 				} else if (mode==3) { // --field
-					fstr << v[field] << " ";
+					pixel[0] = v[field];
 				} else {
 					for (int h = 0; h < v.length(); h++)
-						fstr << v[h] << " ";
+						pixel[h] = v[h];
 				}
 			}
 		}
 	} else if (dim==3) {
+		imageData->SetDimensions(MMSP::x1(GRID)-MMSP::x0(GRID), MMSP::y1(GRID)-MMSP::y0(GRID), MMSP::z1(GRID)-MMSP::z0(GRID));
+		#if VTK_MAJOR_VERSION <= 5
+		if (mode==1 || mode==2 || mode==3)
+			imageData->SetNumberOfScalarComponents(1);
+		else
+			imageData->SetNumberOfScalarComponents(MMSP::fields(GRID));
+		#else
+		if (mode==1 || mode==2 || mode==3)
+			imageData->AllocateScalars(VTK_DOUBLE, 1);
+		else
+			imageData->AllocateScalars(VTK_DOUBLE, MMSP::fields(GRID));
+		#endif
+
 		MMSP::vector<int> x(3,0);
 		for (x[2]=MMSP::z0(GRID); x[2]<MMSP::z1(GRID); x[2]++) {
 			for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
 				for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
 					const MMSP::vector<T>& v = GRID(x);
+					double* pixel = static_cast<double*>(imageData->GetScalarPointer(x[0] - MMSP::x0(GRID), x[1] - MMSP::y0(GRID), x[2] - MMSP::z0(GRID)));
 					if (mode==1) { // --mag
 						double sum = 0.0;
 						for (int h = 0; h < v.length(); h++)
 							sum += v[h]*v[h];
-						fstr << std::sqrt(sum) << " ";
+						pixel[0] = std::sqrt(sum);
 					} else if (mode==2) { // --max
 						// Export index of field with greatest magnitude
 						int max = 0;
 						for (int h = 1; h < v.length(); h++)
 							if (v[h] > v[max])
 								max = h;
-						fstr << max << " ";
+						pixel[0] = max;
 					} else if (mode==3) { // --field
-						fstr << v[field] << " ";
+						pixel[0] = v[field];
 					} else {
 						for (int h = 0; h < v.length(); h++)
-							fstr << v[h] << " ";
+							pixel[h] = v[h];
 					}
 				}
 			}
 		}
 	}
+
+	vtkSmartPointer<vtkXMLImageDataWriter> writer = vtkSmartPointer<vtkXMLImageDataWriter>::New();
+	writer->SetFileName(filename.c_str());
+	// writer->SetCompressorType(ZLIB);
+	#if VTK_MAJOR_VERSION <= 5
+	writer->SetInputConnection(imageData->GetProducerPort());
+	#else
+	writer->SetInputData(imageData);
+	#endif
+	writer->Write();
 }
 
-template<int dim, typename T> void print_sparses(std::ofstream& fstr, const MMSP::grid<dim,MMSP::sparse<T> >& GRID,
-                                                const int& mode, const int& field)
+template<int dim, typename T> void print_sparses(std::string filename, const MMSP::grid<dim,MMSP::sparse<T> >& GRID,
+        const int mode, const int field)
 {
+	vtkSmartPointer<vtkImageData> imageData = vtkSmartPointer<vtkImageData>::New();
+	imageData->SetDimensions(MMSP::xlength(GRID, 0), MMSP::xlength(GRID, 1), MMSP::xlength(GRID, 2));
+	#if VTK_MAJOR_VERSION <= 5
+	imageData->SetNumberOfScalarComponents(1);
+	imageData->SetScalarTypeToDouble();
+	#else
+	imageData->AllocateScalars(VTK_DOUBLE, 1);
+	#endif
+
 	if (dim==1) {
 		MMSP::vector<int> x(1,0);
 		for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
 			const MMSP::sparse<T>& s = GRID(x);
+			double* pixel = static_cast<double*>(imageData->GetScalarPointer(x[0] - MMSP::x0(GRID), 0, 0));
 			if (mode==2) { // --max
 				// Export index of field with greatest magnitude
 				int max = 0;
 				for (int h = 1; h < s.length(); h++)
 					if (s.value(h) > s.value(max))
 						max = h;
-				fstr << s.index(max) << " ";
+				pixel[0] =  s.index(max);
 			} else if (mode==3) { // --field
-				fstr << s[field] << " ";
+				pixel[0] = s[field];
 			} else { // --mag is redundant for sparse
 				double sum = 0.0;
 				for (int h = 0; h < s.length(); h++)
 					sum += s.value(h)*s.value(h);
-				fstr << std::sqrt(sum) << " ";
+				pixel[0] = std::sqrt(sum);
 			}
 		}
 	} else if (dim==2) {
@@ -156,20 +248,21 @@ template<int dim, typename T> void print_sparses(std::ofstream& fstr, const MMSP
 		for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
 			for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
 				const MMSP::sparse<T>& s = GRID(x);
+				double* pixel = static_cast<double*>(imageData->GetScalarPointer(x[0] - MMSP::x0(GRID), x[1] - MMSP::y0(GRID), 0));
 				if (mode==2) { // --max
 					// Export index of field with greatest magnitude
 					int max = 0;
 					for (int h = 1; h < s.length(); h++)
 						if (s.value(h) > s.value(max))
 							max = h;
-					fstr << s.index(max) << " ";
+					pixel[0] =  s.index(max);
 				} else if (mode==3) { // --field
-					fstr << s[field] << " ";
+					pixel[0] = s[field];
 				} else { // --mag is redundant for sparse
 					double sum = 0.0;
 					for (int h = 0; h < s.length(); h++)
 						sum += s.value(h)*s.value(h);
-					fstr << std::sqrt(sum) << " ";
+					pixel[0] = std::sqrt(sum);
 				}
 			}
 		}
@@ -179,25 +272,36 @@ template<int dim, typename T> void print_sparses(std::ofstream& fstr, const MMSP
 			for (x[1]=MMSP::y0(GRID); x[1]<MMSP::y1(GRID); x[1]++) {
 				for (x[0]=MMSP::x0(GRID); x[0]<MMSP::x1(GRID); x[0]++) {
 					const MMSP::sparse<T>& s = GRID(x);
+					double* pixel = static_cast<double*>(imageData->GetScalarPointer(x[0] - MMSP::x0(GRID), x[1] - MMSP::y0(GRID), x[2] - MMSP::z0(GRID)));
 					if (mode==2) { // --max
 						// Export index of field with greatest magnitude
 						int max = 0;
 						for (int h = 1; h < s.length(); h++)
 							if (s.value(h) > s.value(max))
 								max = h;
-						fstr << s.index(max) << " ";
+						pixel[0] =  s.index(max);
 					} else if (mode==3) { // --field
-						fstr << s[field] << " ";
+						pixel[0] = s[field];
 					} else { // --mag is redundant for sparse
 						double sum = 0.0;
 						for (int h = 0; h < s.length(); h++)
 							sum += s.value(h)*s.value(h);
-						fstr << std::sqrt(sum) << " ";
+						pixel[0] = std::sqrt(sum);
 					}
 				}
 			}
 		}
 	}
+
+	vtkSmartPointer<vtkXMLImageDataWriter> writer = vtkSmartPointer<vtkXMLImageDataWriter>::New();
+	writer->SetFileName(filename.c_str());
+	// writer->SetCompressorType(ZLIB);
+	#if VTK_MAJOR_VERSION <= 5
+	writer->SetInputConnection(imageData->GetProducerPort());
+	#else
+	writer->SetInputData(imageData);
+	#endif
+	writer->Write();
 }
 
 int main(int argc, char* argv[])
@@ -248,14 +352,6 @@ int main(int argc, char* argv[])
 	else
 		filename << argv[fileindex+1];
 
-	// file open error check
-	std::ofstream output(filename.str().c_str());
-	if (!output) {
-		std::cerr << "File output error: could not open ";
-		std::cerr << filename.str() << "." << std::endl;
-		exit(-1);
-	}
-
 	// read data type
 	std::string type;
 	getline(input, type, '\n');
@@ -280,17 +376,16 @@ int main(int argc, char* argv[])
 	bool double_type = (type.find("double") != std::string::npos);
 	bool long_double_type = (type.find("long double") != std::string::npos);
 
-	bool scalar_type = (type.find("scalar") != std::string::npos);
 	bool vector_type = (type.find("vector") != std::string::npos);
 	bool sparse_type = (type.find("sparse") != std::string::npos);
 
 	if (not bool_type    and
-	        not char_type    and  not unsigned_char_type   and
-	        not int_type     and  not unsigned_int_type    and
-	        not long_type    and  not unsigned_long_type   and
-	        not short_type   and  not unsigned_short_type  and
-	        not float_type   and
-	        not double_type  and  not long_double_type) {
+	    not char_type    and  not unsigned_char_type   and
+	    not int_type     and  not unsigned_int_type    and
+	    not long_type    and  not unsigned_long_type   and
+	    not short_type   and  not unsigned_short_type  and
+	    not float_type   and
+	    not double_type  and  not long_double_type) {
 		std::cerr << "File input error: unknown grid data type." << std::endl;
 		exit(-1);
 	}
@@ -303,726 +398,413 @@ int main(int argc, char* argv[])
 		exit(-1);
 	}
 
-	// read number of fields
-	int fields;
-	input >> fields;
-
-	// read grid sizes
-	int x0[3] = {0, 0, 0};
-	int x1[3] = {0, 0, 0};
-	for (int i = 0; i < dim; i++)
-		input >> x0[i] >> x1[i];
-
-	// read cell spacing
-	float dx[3] = {1.0, 1.0, 1.0};
-	for (int i = 0; i < dim; i++)
-		input >> dx[i];
-
-	// ignore trailing endlines
-	input.ignore(10, '\n');
-
-
-	// determine byte order: 01 AND 01 = 01; 01 AND 10 = 00.
-	std::string byte_order;
-	if (0x01 & static_cast<int>(1)) byte_order = "LittleEndian";
-	else byte_order = "BigEndian";
-
-	// output header markup
-	output << "<?xml version=\"1.0\"?>\n";
-	output << "<VTKFile type=\"ImageData\" version=\"0.1\" byte_order=\"" << byte_order << "\">\n";
-
-	if (dim == 1) {
-		output << "  <ImageData WholeExtent=\"" << x0[0] << " " << x1[0] << " 0 0 0 0\"";
-		output << "   Origin=\"0 0 0\" Spacing=\"" << dx[0] << " 1 1\">\n";
-	} else if (dim == 2) {
-		output << "  <ImageData WholeExtent=\"" << x0[0] << " " << x1[0] << " "
-		                                        << x0[1] << " " << x1[1]
-		                                        << " 0 0\"";
-		output << "   Origin=\"0 0 0\" Spacing=\"" << dx[0] << " " << dx[1] << " 1\">\n";
-	} else if (dim == 3) {
-		output << "  <ImageData WholeExtent=\"" << x0[0] << " " << x1[0] << " "
-		                                        << x0[1] << " " << x1[1] << " "
-		                                        << x0[2] << " " << x1[2] << "\"";
-		output << "   Origin=\"0 0 0\" Spacing=\"" << dx[0] << " " << dx[1] << " " << dx[2] << "\">\n";
-	} else {
-		std::cerr<<"Error: "<<dim<<"-dimensional data not supported."<<std::endl;
-		std::exit(-1);
+	// write grid data
+	if (not vector_type and not sparse_type) { // must be scalar or built-in
+		if (bool_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::scalar<bool> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::scalar<bool> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::scalar<bool> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			}
+		} else if (unsigned_char_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::scalar<unsigned char> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::scalar<unsigned char> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::scalar<unsigned char> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			}
+		} else if (char_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::scalar<char> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::scalar<char> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::scalar<char> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			}
+		} else if (unsigned_int_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::scalar<unsigned int> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::scalar<unsigned int> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::scalar<unsigned int> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			}
+		} else if (int_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::scalar<int> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::scalar<int> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::scalar<int> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			}
+		} else if (unsigned_long_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::scalar<unsigned long> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::scalar<unsigned long> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::scalar<unsigned long> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			}
+		} else if (long_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::scalar<long> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::scalar<long> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::scalar<long> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			}
+		} else if (unsigned_short_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::scalar<unsigned short> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::scalar<unsigned short> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::scalar<unsigned short> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			}
+		} else if (short_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::scalar<short> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::scalar<short> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::scalar<short> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			}
+		} else if (float_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::scalar<float> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::scalar<float> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::scalar<float> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			}
+		} else if (long_double_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::scalar<long double> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::scalar<long double> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::scalar<long double> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			}
+		} else if (double_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::scalar<double> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::scalar<double> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::scalar<double> > GRID(argv[fileindex]);
+				print_scalars(filename.str(), GRID, flatten);
+			}
+		}
 	}
 
-	// read number of blocks
-	int blocks;
-	input.read(reinterpret_cast<char*>(&blocks), sizeof(blocks));
-
-	for (int i = 0; i < blocks; i++) {
-		// read block limits
-		int lmin[3] = {0, 0, 0};
-		int lmax[3] = {0, 0, 0};
-		for (int j = 0; j < dim; j++) {
-			input.read(reinterpret_cast<char*>(&lmin[j]), sizeof(lmin[j]));
-			input.read(reinterpret_cast<char*>(&lmax[j]), sizeof(lmax[j]));
-		}
-		int blo[3];
-		int bhi[3];
-		// read boundary conditions
-		for (int j = 0; j < dim; j++) {
-			input.read(reinterpret_cast<char*>(&blo[j]), sizeof(blo[j]));
-			input.read(reinterpret_cast<char*>(&bhi[j]), sizeof(bhi[j]));
-		}
-
-		// write header markup
-		if (dim == 1)
-			output << "    <Piece Extent=\"" << lmin[0] << " " << lmax[0] << " 0 0 0 0\">\n";
-		if (dim == 2)
-			output << "    <Piece Extent=\"" << lmin[0] << " " << lmax[0] << " "
-			                                 << lmin[1] << " " << lmax[1] << " 0 0\">\n";
-		if (dim == 3)
-			output << "    <Piece Extent=\"" << lmin[0] << " " << lmax[0] << " "
-			                                 << lmin[1] << " " << lmax[1] << " "
-			                                 << lmin[2] << " " << lmax[2] << "\">\n";
-
-		// write cell data markup
-		if (scalar_type || flatten>0) {
-			output << "      <CellData>\n";
-			output << "        <DataArray Name=\"scalar_data\"";
-		}
-
-		else if (vector_type) {
-			output << "      <CellData>\n";
-			output << "        <DataArray Name=\"vector_data\" NumberOfComponents=\"" << fields << "\"";
-		}
-
-		else if (sparse_type) {
-			output << "      <CellData>\n";
-			output << "        <DataArray Name=\"scalar_data\"";
-		}
-
-		else { /* built-in data types */
-			output << "      <CellData>\n";
-			output << "        <DataArray Name=\"scalar_data\"";
-		}
-
-		if (flatten==1) // mag
-			output << " type=\"Float32\" format=\"ascii\">\n";
-		else if (flatten==2) // max
-			output << " type=\"Int32\" format=\"ascii\">\n";
-		else if (bool_type)
-			output << " type=\"UInt8\" format=\"ascii\">\n";
-		else if (char_type)
-			output << " type=\"Int8\" format=\"ascii\">\n";
-		else if (unsigned_char_type)
-			output << " type=\"UInt8\" format=\"ascii\">\n";
-		else if (int_type)
-			output << " type=\"Int32\" format=\"ascii\">\n";
-		else if (unsigned_int_type)
-			output << " type=\"UInt32\" format=\"ascii\">\n";
-		else if (long_type)
-			output << " type=\"Int32\" format=\"ascii\">\n";
-		else if (unsigned_long_type)
-			output << " type=\"UInt32\" format=\"ascii\">\n";
-		else if (short_type)
-			output << " type=\"Int16\" format=\"ascii\">\n";
-		else if (unsigned_short_type)
-			output << " type=\"UInt16\" format=\"ascii\">\n";
-		else if (float_type)
-			output << " type=\"Float32\" format=\"ascii\">\n";
-		else if (double_type)
-			output << " type=\"Float64\" format=\"ascii\">\n";
-		else if (long_double_type)
-			output << " type=\"Float128\" format=\"ascii\">\n";
-
-
-		// read grid data
-		unsigned long size, rawSize;
-		input.read(reinterpret_cast<char*>(&rawSize), sizeof(rawSize)); // read raw size
-		input.read(reinterpret_cast<char*>(&size), sizeof(size)); // read compressed size
-		char* compressed_buffer = new char[size];
-		input.read(compressed_buffer, size);
-		char* buffer = NULL;
-		if (size != rawSize) {
-			// Decompress data
-			buffer = new char[rawSize];
-			int status;
-			status = uncompress(reinterpret_cast<unsigned char*>(buffer), &rawSize, reinterpret_cast<unsigned char*>(compressed_buffer), size);
-			switch(status) {
-			case Z_OK:
-				break;
-			case Z_MEM_ERROR:
-				std::cerr << "Uncompress: out of memory." << std::endl;
-				exit(1);
-				break;
-			case Z_BUF_ERROR:
-				std::cerr << "Uncompress: output buffer wasn't large enough." << std::endl;
-				exit(1);
-				break;
+	else if (vector_type) {
+		if (bool_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::vector<bool> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::vector<bool> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::vector<bool> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
 			}
-			delete [] compressed_buffer;
-			compressed_buffer = NULL;
-		} else {
-			buffer = compressed_buffer;
-			compressed_buffer = NULL;
-		}
-
-		// write grid data
-		if (not vector_type and not sparse_type) { // must be scalar or built-in
-			if (bool_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::scalar<bool> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::scalar<bool> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::scalar<bool> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				}
+		} else if (unsigned_char_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::vector<unsigned char> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::vector<unsigned char> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::vector<unsigned char> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
 			}
-			else if (unsigned_char_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::scalar<unsigned char> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::scalar<unsigned char> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-						print_scalars(output, GRID, flatten);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::scalar<unsigned char> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				}
+		} else if (char_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::vector<char> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::vector<char> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::vector<char> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
 			}
-			else if (char_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::scalar<char> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::scalar<char> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::scalar<char> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				}
+		} else if (unsigned_int_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::vector<unsigned int> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::vector<unsigned int> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::vector<unsigned int> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
 			}
-			else if (unsigned_int_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::scalar<unsigned int> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::scalar<unsigned int> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::scalar<unsigned int> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				}
+		} else if (int_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::vector<int> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::vector<int> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::vector<int> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
 			}
-			else if (int_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::scalar<int> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::scalar<int> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::scalar<int> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				}
+		} else if (unsigned_long_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::vector<unsigned long> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::vector<unsigned long> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::vector<unsigned long> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
 			}
-			else if (unsigned_long_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::scalar<unsigned long> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::scalar<unsigned long> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::scalar<unsigned long> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				}
+		} else if (long_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::vector<long> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::vector<long> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::vector<long> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
 			}
-			else if (long_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::scalar<long> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::scalar<long> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::scalar<long> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				}
+		} else if (unsigned_short_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::vector<unsigned short> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::vector<unsigned short> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::vector<unsigned short> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
 			}
-			else if (unsigned_short_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::scalar<unsigned short> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::scalar<unsigned short> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::scalar<unsigned short> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				}
+		} else if (short_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::vector<short> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::vector<short> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::vector<short> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
 			}
-			else if (short_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::scalar<short> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::scalar<short> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::scalar<short> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				}
+		} else if (float_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::vector<float> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::vector<float> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::vector<float> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
 			}
-			else if (float_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::scalar<float> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::scalar<float> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::scalar<float> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				}
+		} else if (long_double_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::vector<long double> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::vector<long double> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::vector<long double> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
 			}
-			else if (long_double_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::scalar<long double> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::scalar<long double> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::scalar<long double> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				}
-			}
-			else if (double_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::scalar<double> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::scalar<double> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::scalar<double> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_scalars(output, GRID, flatten);
-				}
+		} else if (double_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::vector<double> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::vector<double> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::vector<double> > GRID(argv[fileindex]);
+				print_vectors(filename.str(), GRID, flatten, field);
 			}
 		}
-
-		else if (vector_type) {
-			if (bool_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::vector<bool> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::vector<bool> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::vector<bool> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				}
-			}
-			else if (unsigned_char_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::vector<unsigned char> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::vector<unsigned char> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::vector<unsigned char> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				}
-			}
-			else if (char_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::vector<char> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::vector<char> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::vector<char> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				}
-			}
-			else if (unsigned_int_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::vector<unsigned int> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::vector<unsigned int> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::vector<unsigned int> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				}
-			}
-			else if (int_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::vector<int> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::vector<int> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::vector<int> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				}
-			}
-			else if (unsigned_long_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::vector<unsigned long> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::vector<unsigned long> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::vector<unsigned long> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				}
-			}
-			else if (long_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::vector<long> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::vector<long> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::vector<long> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				}
-			}
-			else if (unsigned_short_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::vector<unsigned short> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::vector<unsigned short> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::vector<unsigned short> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				}
-			}
-			else if (short_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::vector<short> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::vector<short> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::vector<short> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				}
-			}
-			else if (float_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::vector<float> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::vector<float> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::vector<float> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				}
-			}
-			else if (long_double_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::vector<long double> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::vector<long double> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::vector<long double> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				}
-			}
-			else if (double_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::vector<double> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::vector<double> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::vector<double> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_vectors(output, GRID, flatten, field);
-				}
-			}
-		}
-
-		else if (sparse_type) {
-			if (bool_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::sparse<bool> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::sparse<bool> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::sparse<bool> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				}
-			}
-			else if (unsigned_char_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::sparse<unsigned char> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::sparse<unsigned char> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::sparse<unsigned char> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				}
-			}
-			else if (char_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::sparse<char> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::sparse<char> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::sparse<char> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				}
-			}
-			else if (unsigned_int_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::sparse<unsigned int> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::sparse<unsigned int> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::sparse<unsigned int> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				}
-			}
-			else if (int_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::sparse<int> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::sparse<int> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::sparse<int> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				}
-			}
-			else if (unsigned_long_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::sparse<unsigned long> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::sparse<unsigned long> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::sparse<unsigned long> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				}
-			}
-			else if (long_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::sparse<long> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::sparse<long> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::sparse<long> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				}
-			}
-			else if (unsigned_short_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::sparse<unsigned short> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::sparse<unsigned short> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::sparse<unsigned short> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				}
-			}
-			else if (short_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::sparse<short> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::sparse<short> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::sparse<short> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				}
-			}
-			else if (float_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::sparse<float> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::sparse<float> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::sparse<float> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				}
-			}
-			else if (long_double_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::sparse<long double> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::sparse<long double> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::sparse<long double> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				}
-			}
-			else if (double_type) {
-				if (dim == 1) {
-					MMSP::grid<1, MMSP::sparse<double> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 2) {
-					MMSP::grid<2, MMSP::sparse<double> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				} else if (dim == 3) {
-					MMSP::grid<3, MMSP::sparse<double> > GRID(fields, lmin, lmax);
-					GRID.from_buffer(buffer);
-					print_sparses(output, GRID, flatten, field);
-				}
-			}
-		}
-
-		// clean up
-		delete [] buffer;
-
-		// write closing markup
-		output << "\n";
-		output << "        </DataArray>\n";
-		output << "      </CellData>\n";
-		output << "    </Piece>\n";
 	}
 
-// output closing markup
-	output << "  </ImageData>\n";
-	output << "</VTKFile>\n";
+	else if (sparse_type) {
+		if (bool_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::sparse<bool> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::sparse<bool> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::sparse<bool> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			}
+		} else if (unsigned_char_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::sparse<unsigned char> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::sparse<unsigned char> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::sparse<unsigned char> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			}
+		} else if (char_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::sparse<char> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::sparse<char> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::sparse<char> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			}
+		} else if (unsigned_int_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::sparse<unsigned int> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::sparse<unsigned int> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::sparse<unsigned int> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			}
+		} else if (int_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::sparse<int> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::sparse<int> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::sparse<int> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			}
+		} else if (unsigned_long_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::sparse<unsigned long> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::sparse<unsigned long> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::sparse<unsigned long> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			}
+		} else if (long_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::sparse<long> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::sparse<long> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::sparse<long> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			}
+		} else if (unsigned_short_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::sparse<unsigned short> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::sparse<unsigned short> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::sparse<unsigned short> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			}
+		} else if (short_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::sparse<short> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::sparse<short> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::sparse<short> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			}
+		} else if (float_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::sparse<float> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::sparse<float> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::sparse<float> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			}
+		} else if (long_double_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::sparse<long double> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::sparse<long double> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::sparse<long double> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			}
+		} else if (double_type) {
+			if (dim == 1) {
+				MMSP::grid<1, MMSP::sparse<double> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 2) {
+				MMSP::grid<2, MMSP::sparse<double> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			} else if (dim == 3) {
+				MMSP::grid<3, MMSP::sparse<double> > GRID(argv[fileindex]);
+				print_sparses(filename.str(), GRID, flatten, field);
+			}
+		}
+	}
+
 }


### PR DESCRIPTION
`mmsp2vti` presently reads in an MMSP grid file, then, block-by-block, writes an XML file in ASCII VTK syntax. This works, but is inflexible: for example, saving disk space using binary encoding or compression would be cumbersome. Furthermore, this is [somebody else's job](https://www.vtk.org/).

This contribution replaces the homegrown data conversion with calls to the VTK API. This compresses the VTK XML file by default, and should improve maintainability of the MMSP codebase. The downside is that VTK is now a dependency, and it can be a tedious one to manage. The trade-off is, in my opinion, worthwhile.

Closes #63.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mesoscale/mmsp/64)
<!-- Reviewable:end -->
