### PR TITLE
converted gradient function to standard forward difference

### DIFF
--- a/include/MMSP.grid.cpp
+++ b/include/MMSP.grid.cpp
@@ -2146,11 +2146,11 @@ template <int dim, typename T> MMSP::vector<T> gradient(const grid<dim, T>& GRID
 	for (int i=0; i<dim; i++) {
 		s[i] += 1;
 		const T& yh = GRID(s);
-		s[i] -= 2;
+		s[i] -= 1;
 		const T& yl = GRID(s);
-		s[i] += 1;
+		//s[i] += 1;
 
-		double weight = 1.0 / (2.0 * dx(GRID, i));
+		double weight = 1.0 / (1.0 * dx(GRID, i));
 		gradient[i] = weight * (yh - yl);
 	}
 	return gradient;
@@ -2164,11 +2164,11 @@ template <int dim, typename T> MMSP::vector<T> gradient(const grid<dim,vector<T>
 	for (int i=0; i<dim; i++) {
 		s[i] += 1;
 		const T& yh = GRID(s)[field];
-		s[i] -= 2;
+		s[i] -= 1;
 		const T& yl = GRID(s)[field];
-		s[i] += 1;
+		//s[i] += 1;
 
-		double weight = 1.0 / (2.0 * dx(GRID, i));
+		double weight = 1.0 / (1.0 * dx(GRID, i));
 		gradient[i] = weight * (yh - yl);
 	}
 	return gradient;


### PR DESCRIPTION
The proposed changes are intended to {improve the numerics of the gradient function. Currently the gradient is kind of a sum of forward and backwards fifferences: a(x+1)-a(x-1)/2dx. I think this doubles the error}.

This is achieved by {I have converted the gradients to a standard forward difference}.

Fixes #, Addresses #

The modified code may have unintended consequences in {I dont forsee any unintended consequences. The old method may have performed some unintended averaging where used so we should look out for this}.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mesoscale/mmsp/68)
<!-- Reviewable:end -->
