### PR TITLE
Heat conduction examples

### DIFF
--- a/examples/HeatConduction/heterogeneous/Makefile
+++ b/examples/HeatConduction/heterogeneous/Makefile
@@ -1,0 +1,22 @@
+# hetHC.cpp
+# Algorithms for 2D heterogeneous heat conduction, where alpha varies spatially
+# Questions/comments to thomas.flint@manchester.ac.uk (Tom Flint)
+
+# includes
+incdir = ../../../include
+
+# compilers/flags
+compiler = g++
+pcompiler = mpic++
+flags = -O3 -I $(incdir)
+pflags = $(flags) -include mpi.h
+
+# the program
+hetHC: hetHC.cpp
+	$(compiler) $(flags) $< -o $@ -lz
+
+parallel: hetHC.cpp
+	$(pcompiler) $(pflags) $< -o $@ -lz
+
+clean:
+	rm -f hetHC parallel alpha

--- a/examples/HeatConduction/heterogeneous/hetHC.cpp
+++ b/examples/HeatConduction/heterogeneous/hetHC.cpp
@@ -1,0 +1,123 @@
+// hetHC.cpp
+// Algorithms for 2D heterogeneous heat conduction, where alpha varies spatially
+// Questions/comments to thomas.flint@manchester.ac.uk (Tom Flint)
+
+#ifndef HETHC_UPDATE
+#define HETHC_UPDATE
+#include"MMSP.hpp"
+#include<cmath>
+#include"hetHC.hpp"
+
+namespace MMSP{
+
+
+
+void generate(int dim, const char* filename)
+{
+	if (dim==1) {
+	std::cerr << "Heat Conduction code is only implemented for 2D." << std::endl;
+		MMSP::Abort(-1);
+	}
+
+	if (dim==2) {
+		int L=256;
+		GRID2D initGrid(0,0,L,0,L);
+
+		for (int i=0; i<nodes(initGrid); i++)
+		//vector<int> x = position(initGrid,i);
+		//if(x[0]<=1){
+			//initGrid(i)=1.0;
+		//	}
+		//else{
+			initGrid(i) = 0.0;
+		//}
+
+
+		output(initGrid,filename);
+	}
+
+	if (dim==3) {
+std::cerr << "Heat Conduction code is only implemented for 2D." << std::endl;
+		MMSP::Abort(-1);
+	}
+}
+
+template <int dim, typename T> void update(grid<dim,T>& oldGrid, int steps)
+{
+	int rank=0;
+    #ifdef MPI_VERSION
+    rank = MPI::COMM_WORLD.Get_rank();
+    #endif
+
+	ghostswap(oldGrid);
+
+
+ MMSP::grid<2,double > GRID_Diffusivity(1,0,256,0,256);     //for storing phase data
+//dx(GRID_Diffusivity,0)=deltaX;
+//dx(GRID_Diffusivity,1)=deltaY;
+
+
+
+	grid<dim, double> newGrid(oldGrid);
+
+
+	double dt = 1e-2;
+
+
+	for (int step=0; step<steps; step++) {
+		if (rank==0)
+			print_progress(step, steps);
+
+		for (int i=0; i<nodes(oldGrid); i++) {
+			vector<int> x = position(oldGrid,i);
+			if(x[1]>(256/2)+5){
+			GRID_Diffusivity(i)=0.5;
+			}
+			else if(x[1]<(256/2)-5){
+			GRID_Diffusivity(i)=0.5;
+			}
+
+			else{
+			GRID_Diffusivity(i)=10.0;
+			}
+
+			if(x[0]<=1){
+			oldGrid(i)=1.0;
+			}
+
+		}
+		MMSP::output(GRID_Diffusivity, "alpha");
+
+
+		for (int i=0; i<nodes(oldGrid); i++) {
+			vector<int> x = position(oldGrid,i);
+			double old = oldGrid(i);
+
+			vector<double> GRID_gradD = grad(GRID_Diffusivity,x);
+			vector<double> GRID_gradT = grad(oldGrid,x);
+			
+			double lapT=laplacian(oldGrid,i);
+			
+			double dTdt=(GRID_gradD[0]*GRID_gradT[0])+(GRID_gradD[1]*GRID_gradT[1])+(GRID_Diffusivity(i)*lapT);
+
+			newGrid(i) = old+(dt*dTdt);
+			
+			if(x[0]<=1){
+			newGrid(i)=1.0;
+			}
+			if(x[0]>=250){
+			newGrid(i)=oldGrid(i);
+			}
+
+		}
+		swap(oldGrid,newGrid);
+		ghostswap(oldGrid);
+	}
+
+}
+
+} // namespace MMSP
+
+#endif
+
+#include"MMSP.main.hpp"

--- a/examples/HeatConduction/heterogeneous/hetHC.hpp
+++ b/examples/HeatConduction/heterogeneous/hetHC.hpp
@@ -1,0 +1,11 @@
+// hetHC.hpp
+// Algorithms for 2D heterogeneous heat conduction, where alpha varies spatially
+// Questions/comments to thomas.flint@manchester.ac.uk (Tom Flint)
+
+std::string PROGRAM = "hetHC";
+std::string MESSAGE = "\"heterogeneous heat conduction\" using MMSP";
+
+typedef MMSP::grid<1,double> GRID1D;
+typedef MMSP::grid<2,double> GRID2D;
+typedef MMSP::grid<3,double> GRID3D;
+

--- a/examples/HeatConduction/homogeneous/Makefile
+++ b/examples/HeatConduction/homogeneous/Makefile
@@ -1,0 +1,22 @@
+# homHC.cpp
+# Algorithms for 2D homogeneous heat conduction
+# Questions/comments to thomas.flint@manchester.ac.uk (Tom Flint)
+
+# includes
+incdir = ../../../include
+
+# compilers/flags
+compiler = g++
+pcompiler = mpic++
+flags = -O3 -I $(incdir)
+pflags = $(flags) -include mpi.h
+
+# the program
+homHC: homHC.cpp
+	$(compiler) $(flags) $< -o $@ -lz
+
+parallel: homHC.cpp
+	$(pcompiler) $(pflags) $< -o $@ -lz
+
+clean:
+	rm -f homHC parallel

--- a/examples/HeatConduction/homogeneous/homHC.cpp
+++ b/examples/HeatConduction/homogeneous/homHC.cpp
@@ -1,0 +1,114 @@
+// hetHC.cpp
+// Algorithms for 2D homogeneous heat conduction
+// Questions/comments to thomas.flint@manchester.ac.uk (Tom Flint)
+
+#ifndef HETHC_UPDATE
+#define HETHC_UPDATE
+#include"MMSP.hpp"
+#include<cmath>
+#include"homHC.hpp"
+
+namespace MMSP{
+
+
+
+void generate(int dim, const char* filename)
+{
+	if (dim==1) {
+	std::cerr << "Heat Conduction code is only implemented for 2D." << std::endl;
+		MMSP::Abort(-1);
+	}
+
+	if (dim==2) {
+		int L=256;
+		GRID2D initGrid(0,0,L,0,L);
+
+		for (int i=0; i<nodes(initGrid); i++)
+		//vector<int> x = position(initGrid,i);
+		//if(x[0]<=1){
+			//initGrid(i)=1.0;
+		//	}
+		//else{
+			initGrid(i) = 0.0;
+		//}
+
+
+		output(initGrid,filename);
+	}
+
+	if (dim==3) {
+std::cerr << "Heat Conduction code is only implemented for 2D." << std::endl;
+		MMSP::Abort(-1);
+	}
+}
+
+template <int dim, typename T> void update(grid<dim,T>& oldGrid, int steps)
+{
+	int rank=0;
+    #ifdef MPI_VERSION
+    rank = MPI::COMM_WORLD.Get_rank();
+    #endif
+
+	ghostswap(oldGrid);
+
+
+ MMSP::grid<2,double > GRID_Diffusivity(1,0,256,0,256);     //for storing phase data
+//dx(GRID_Diffusivity,0)=deltaX;
+//dx(GRID_Diffusivity,1)=deltaY;
+
+
+
+	grid<dim, double> newGrid(oldGrid);
+
+
+	double dt = 1e-2;
+
+
+	for (int step=0; step<steps; step++) {
+		if (rank==0)
+			print_progress(step, steps);
+
+		for (int i=0; i<nodes(oldGrid); i++) {
+			vector<int> x = position(oldGrid,i);
+			GRID_Diffusivity(i)=10.0;
+
+			if(x[0]<=1){
+			oldGrid(i)=1.0;
+			}
+
+		}
+		MMSP::output(GRID_Diffusivity, "alpha");
+
+
+		for (int i=0; i<nodes(oldGrid); i++) {
+			vector<int> x = position(oldGrid,i);
+			double old = oldGrid(i);
+
+			vector<double> GRID_gradD = grad(GRID_Diffusivity,x);
+			vector<double> GRID_gradT = grad(oldGrid,x);
+			
+			double lapT=laplacian(oldGrid,i);
+			
+			double dTdt=(GRID_Diffusivity(i)*lapT);
+
+			newGrid(i) = old+(dt*dTdt);
+			
+			if(x[0]<=1){
+			newGrid(i)=1.0;
+			}
+			if(x[0]>=250){
+			newGrid(i)=oldGrid(i);
+			}
+
+		}
+		swap(oldGrid,newGrid);
+		ghostswap(oldGrid);
+	}
+
+}
+
+} // namespace MMSP
+
+#endif
+
+#include"MMSP.main.hpp"

--- a/examples/HeatConduction/homogeneous/homHC.hpp
+++ b/examples/HeatConduction/homogeneous/homHC.hpp
@@ -1,0 +1,11 @@
+// hetHC.hpp
+// Algorithms for 2D homogeneous heat conduction
+// Questions/comments to thomas.flint@manchester.ac.uk (Tom Flint)
+
+std::string PROGRAM = "hetHC";
+std::string MESSAGE = "\"heterogeneous heat conduction\" using MMSP";
+
+typedef MMSP::grid<1,double> GRID1D;
+typedef MMSP::grid<2,double> GRID2D;
+typedef MMSP::grid<3,double> GRID3D;
+

--- a/include/MMSP.grid.cpp
+++ b/include/MMSP.grid.cpp
@@ -2146,11 +2146,11 @@ template <int dim, typename T> MMSP::vector<T> gradient(const grid<dim, T>& GRID
 	for (int i=0; i<dim; i++) {
 		s[i] += 1;
 		const T& yh = GRID(s);
-		s[i] -= 2;
+		s[i] -= 1;
 		const T& yl = GRID(s);
-		s[i] += 1;
+		//s[i] += 1;
 
-		double weight = 1.0 / (2.0 * dx(GRID, i));
+		double weight = 1.0 / (1.0 * dx(GRID, i));
 		gradient[i] = weight * (yh - yl);
 	}
 	return gradient;
@@ -2164,11 +2164,11 @@ template <int dim, typename T> MMSP::vector<T> gradient(const grid<dim,vector<T>
 	for (int i=0; i<dim; i++) {
 		s[i] += 1;
 		const T& yh = GRID(s)[field];
-		s[i] -= 2;
+		s[i] -= 1;
 		const T& yl = GRID(s)[field];
-		s[i] += 1;
+		//s[i] += 1;
 
-		double weight = 1.0 / (2.0 * dx(GRID, i));
+		double weight = 1.0 / (1.0 * dx(GRID, i));
 		gradient[i] = weight * (yh - yl);
 	}
 	return gradient;

--- a/test/build_examples.sh
+++ b/test/build_examples.sh
@@ -170,6 +170,8 @@ fi
 echo "---------------------------------------------------------------------------"
 
 exdirs=("beginners_diffusion/" \
+"HeatConduction/heterogeneous" \
+"HeatConduction/homogeneous" \
 "coarsening/grain_growth/anisotropic/Monte_Carlo/" \
 "coarsening/grain_growth/anisotropic/phase_field/" \
 "coarsening/grain_growth/anisotropic/sparsePF/" \


### PR DESCRIPTION
The proposed changes are intended to {Add some useful examples for homogeneous and heterogeneous heat conduction. The heterogeneous case has a hot wall with a central region that has a higher thermal diffusivity}.

This is achieved by {An example 'Heat conduction' folder is created in the examples with the homogeneous and heterogeneous examples}.

Fixes #, Addresses #

The modified code may have unintended consequences in {The heterogeneous example relies on the updated gradient fix previously suggested. Without the normal forward differencing the gradient goes haywire at the interface of the high and low diffusivity region (I think this is because of the higher error in this double differencing technique)}.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mesoscale/mmsp/69)
<!-- Reviewable:end -->
