### PR TITLE
Issue71 c++bindings deprecated

### DIFF
--- a/doc/MMSP.chapter3.tex
+++ b/doc/MMSP.chapter3.tex
@@ -34,7 +34,7 @@ and
     MMSP::Finalize();
 \end{verbatim}
 \end{shadebox}
-What do these lines do?  For single processor programs, they do absolutely nothing -- they could actually be removed without any consequences.  However, for programs that use the message passing interface (MPI), they act as wrappers for the similarly named {\tt MPI::Init} and {\tt MPI::Finalize} commands.  It's useful to include them here because they'll allow us to write programs that may be compiled for both single or multiple processor environments.
+What do these lines do?  For single processor programs, they do absolutely nothing -- they could actually be removed without any consequences.  However, for programs that use the message passing interface (MPI), they act as wrappers for the similarly named {\tt MPI_Init} and {\tt MPI_Finalize} commands.  It's useful to include them here because they'll allow us to write programs that may be compiled for both single or multiple processor environments.
 
 Programmers familiar with {\tt c++} will notice that there's obviously some \MMSP\ namespace being used here.  For those less familiar, namespaces are a somewhat recent addition to {\tt c++} that are used as a means of avoiding naming conflicts.  We can avoid using namespace resolution so frequently if we use an appropriate {\tt using} statement, i.e. 
 \begin{shadebox}

--- a/examples/coarsening/grain_growth/anisotropic/Monte_Carlo/Makefile
+++ b/examples/coarsening/grain_growth/anisotropic/Monte_Carlo/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../../../include
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -Wall -I $(incdir)
+flags = -g -Wall -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/coarsening/grain_growth/anisotropic/Monte_Carlo/Makefile
+++ b/examples/coarsening/grain_growth/anisotropic/Monte_Carlo/Makefile
@@ -8,8 +8,8 @@ incdir = ../../../../../include
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -I $(incdir)
-pflags = $(flags) -include mpi.h 
+flags = -O3 -Wall -I $(incdir)
+pflags = $(flags) -include mpi.h
 
 # the program
 graingrowth: graingrowth.cpp

--- a/examples/coarsening/grain_growth/anisotropic/Monte_Carlo/Makefile
+++ b/examples/coarsening/grain_growth/anisotropic/Monte_Carlo/Makefile
@@ -8,8 +8,8 @@ incdir = ../../../../../include
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -g -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+flags = -O3 -Wall -I $(incdir)
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 graingrowth: graingrowth.cpp

--- a/examples/coarsening/grain_growth/anisotropic/Monte_Carlo/graingrowth.cpp
+++ b/examples/coarsening/grain_growth/anisotropic/Monte_Carlo/graingrowth.cpp
@@ -64,7 +64,7 @@ template <int dim> void update(grid<dim, int>& mcGrid, int steps)
 {
 	int rank = 0;
 	#ifdef MPI_VERSION
-	rank = MPI::COMM_WORLD.Get_rank();
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 	#endif
 
 	ghostswap(mcGrid);
@@ -181,7 +181,7 @@ template <int dim> void update(grid<dim, int>& mcGrid, int steps)
 			// This particular algorithm requires that srand() be called here.
 			unsigned long seed=time(NULL);
 			#ifdef MPI_VERSION
-			MPI::COMM_WORLD.Bcast(&seed, 1, MPI_UNSIGNED_LONG, 0);
+			MPI_Bcast(&seed, 1, MPI_UNSIGNED_LONG, 0, MPI_COMM_WORLD);
 			#endif
 			srand(seed); // Also, time(NULL)+rank is an INCORRECT seed for this purpose.
 
@@ -368,7 +368,7 @@ template <int dim> void update(grid<dim, int>& mcGrid, int steps)
 			} // hh
 
 			#ifdef MPI_VERSION
-			MPI::COMM_WORLD.Barrier();
+			MPI_Barrier(MPI_COMM_WORLD);
 			#endif
 			ghostswap(mcGrid, sublattice); // once looped over a "color", ghostswap.
 		}//loop over sublattice

--- a/examples/coarsening/grain_growth/anisotropic/phase_field/Makefile
+++ b/examples/coarsening/grain_growth/anisotropic/phase_field/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../../../include
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -I $(incdir)
+flags = -O3 -Wall -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/coarsening/grain_growth/anisotropic/phase_field/Makefile
+++ b/examples/coarsening/grain_growth/anisotropic/phase_field/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../../../include
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 graingrowth: graingrowth.cpp

--- a/examples/coarsening/grain_growth/anisotropic/phase_field/graingrowth.cpp
+++ b/examples/coarsening/grain_growth/anisotropic/phase_field/graingrowth.cpp
@@ -95,7 +95,7 @@ template <int dim, typename T> void update(grid<dim,vector<T> >& oldGrid, int st
 {
 	int rank=0;
 	#ifdef MPI_VERSION
-	rank = MPI::COMM_WORLD.Get_rank();
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 	#endif
 
 	ghostswap(oldGrid);

--- a/examples/coarsening/grain_growth/anisotropic/sparsePF/Makefile
+++ b/examples/coarsening/grain_growth/anisotropic/sparsePF/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../../../include
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -I $(incdir)
+flags = -O3 -Wall -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/coarsening/grain_growth/anisotropic/sparsePF/Makefile
+++ b/examples/coarsening/grain_growth/anisotropic/sparsePF/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../../../include
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 graingrowth: graingrowth.cpp

--- a/examples/coarsening/grain_growth/anisotropic/sparsePF/graingrowth.cpp
+++ b/examples/coarsening/grain_growth/anisotropic/sparsePF/graingrowth.cpp
@@ -88,7 +88,7 @@ template <int dim, typename T> void update(grid<dim,sparse<T> >& oldGrid, int st
 {
 	int rank=0;
 	#ifdef MPI_VERSION
-	rank = MPI::COMM_WORLD.Get_rank();
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 	#endif
 	double dt = 0.01;
 	double width = 8.0;

--- a/examples/coarsening/grain_growth/isotropic/Monte_Carlo/Makefile
+++ b/examples/coarsening/grain_growth/isotropic/Monte_Carlo/Makefile
@@ -8,8 +8,8 @@ incdir = ../../../../../include
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -I $(incdir)
-pflags = $(flags) -include mpi.h 
+flags = -O3 -Wall -I $(incdir)
+pflags = $(flags) -include mpi.h
 
 # the program
 graingrowth: graingrowth.cpp

--- a/examples/coarsening/grain_growth/isotropic/Monte_Carlo/Makefile
+++ b/examples/coarsening/grain_growth/isotropic/Monte_Carlo/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../../../include
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 graingrowth: graingrowth.cpp

--- a/examples/coarsening/grain_growth/isotropic/Monte_Carlo/graingrowth.cpp
+++ b/examples/coarsening/grain_growth/isotropic/Monte_Carlo/graingrowth.cpp
@@ -63,7 +63,7 @@ template <int dim> void update(grid<dim, int>& mcGrid, int steps)
 {
 	int rank = 0;
 	#ifdef MPI_VERSION
-	rank = MPI::COMM_WORLD.Get_rank();
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 	#endif
 
 	ghostswap(mcGrid);
@@ -180,7 +180,7 @@ template <int dim> void update(grid<dim, int>& mcGrid, int steps)
 			// This particular algorithm requires that srand() be called here.
 			unsigned long seed=time(NULL);
 			#ifdef MPI_VERSION
-			MPI::COMM_WORLD.Bcast(&seed, 1, MPI_UNSIGNED_LONG, 0);
+			MPI_Bcast(&seed, 1, MPI_UNSIGNED_LONG, 0, MPI_COMM_WORLD);
 			#endif
 			srand(seed); // Also, time(NULL)+rank is an INCORRECT seed for this purpose.
 
@@ -364,7 +364,7 @@ template <int dim> void update(grid<dim, int>& mcGrid, int steps)
 			} // hh
 
 			#ifdef MPI_VERSION
-			MPI::COMM_WORLD.Barrier();
+			MPI_Barrier(MPI_COMM_WORLD);
 			#endif
 			ghostswap(mcGrid, sublattice); // once looped over a "color", ghostswap.
 		}//loop over sublattice

--- a/examples/coarsening/grain_growth/isotropic/phase_field/Makefile
+++ b/examples/coarsening/grain_growth/isotropic/phase_field/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../../../include
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -I $(incdir)
+flags = -O3 -Wall -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/coarsening/grain_growth/isotropic/phase_field/Makefile
+++ b/examples/coarsening/grain_growth/isotropic/phase_field/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../../../include
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 graingrowth: graingrowth.cpp

--- a/examples/coarsening/grain_growth/isotropic/phase_field/graingrowth.cpp
+++ b/examples/coarsening/grain_growth/isotropic/phase_field/graingrowth.cpp
@@ -74,7 +74,7 @@ template <int dim, typename T> void update(grid<dim,vector<T> >& oldGrid, int st
 {
 	int rank=0;
     #ifdef MPI_VERSION
-    rank = MPI::COMM_WORLD.Get_rank();
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     #endif
 
 	ghostswap(oldGrid);
@@ -138,7 +138,7 @@ TEST(grid1DTest, Finite) {
 	#ifdef MPI_VERSION
 	for (int i=0; i<2; i++) {
 		double myLen(length[i]);
-		MPI::COMM_WORLD.Allreduce(&myLen,&length[i],1,MPI_DOUBLE,MPI_SUM);
+		MPI_Allreduce(&myLen,&length[i],1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
 	}
 	#endif
 	for (int n=0; n<MMSP::nodes(myGrid1D); n++)
@@ -160,7 +160,7 @@ TEST(grid2DTest, Finite) {
 	#ifdef MPI_VERSION
 	for (int i=0; i<2; i++) {
 		double myAre(area[i]);
-		MPI::COMM_WORLD.Allreduce(&myAre,&area[i],1,MPI_DOUBLE,MPI_SUM);
+		MPI_Allreduce(&myAre,&area[i],1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
 	}
 	#endif
 	for (int n=0; n<MMSP::nodes(myGrid2D); n++)
@@ -182,7 +182,7 @@ TEST(grid3DTest, Finite) {
 	#ifdef MPI_VERSION
 	for (int i=0; i<1; i++) {
 		double myVol(volume[i]);
-		MPI::COMM_WORLD.Allreduce(&myAre,&volume[i],1,MPI_DOUBLE,MPI_SUM);
+		MPI_Allreduce(&myAre,&volume[i],1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
 	}
 	#endif
 	for (int n=0; n<MMSP::nodes(myGrid3D); n++)

--- a/examples/coarsening/grain_growth/isotropic/sparsePF/Makefile
+++ b/examples/coarsening/grain_growth/isotropic/sparsePF/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../../../include
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -I $(incdir)
+flags = -O3 -Wall -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/coarsening/grain_growth/isotropic/sparsePF/Makefile
+++ b/examples/coarsening/grain_growth/isotropic/sparsePF/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../../../include
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 graingrowth: graingrowth.cpp

--- a/examples/coarsening/grain_growth/isotropic/sparsePF/graingrowth.cpp
+++ b/examples/coarsening/grain_growth/isotropic/sparsePF/graingrowth.cpp
@@ -59,7 +59,7 @@ template <int dim, typename T> void update(grid<dim,sparse<T> >& oldGrid, int st
 {
 	int rank=0;
     #ifdef MPI_VERSION
-    rank = MPI::COMM_WORLD.Get_rank();
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     #endif
 
 	ghostswap(oldGrid);

--- a/examples/coarsening/ostwald_ripening/isotropic/phase_field/Makefile
+++ b/examples/coarsening/ostwald_ripening/isotropic/phase_field/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../../../include
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -I $(incdir)
+flags = -O3 -Wall -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/coarsening/ostwald_ripening/isotropic/phase_field/Makefile
+++ b/examples/coarsening/ostwald_ripening/isotropic/phase_field/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../../../include
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 ostwald: ostwald.cpp

--- a/examples/coarsening/ostwald_ripening/isotropic/phase_field/ostwald.cpp
+++ b/examples/coarsening/ostwald_ripening/isotropic/phase_field/ostwald.cpp
@@ -57,7 +57,7 @@ template <int dim, typename T> void update(grid<dim,vector<T> >& oldGrid, int st
 {
 	int rank=0;
     #ifdef MPI_VERSION
-    rank = MPI::COMM_WORLD.Get_rank();
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     #endif
 
 	ghostswap(oldGrid);

--- a/examples/coarsening/zener_pinning/anisotropic/Monte_Carlo/Makefile
+++ b/examples/coarsening/zener_pinning/anisotropic/Monte_Carlo/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../../../include
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 zener: zener.cpp

--- a/examples/coarsening/zener_pinning/anisotropic/Monte_Carlo/Makefile
+++ b/examples/coarsening/zener_pinning/anisotropic/Monte_Carlo/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../../../include
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -I $(incdir)
+flags = -O3 -Wall -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/coarsening/zener_pinning/anisotropic/Monte_Carlo/zener.cpp
+++ b/examples/coarsening/zener_pinning/anisotropic/Monte_Carlo/zener.cpp
@@ -91,7 +91,7 @@ template <int dim> void update(grid<dim,int>& mcGrid, int steps)
 {
 	int rank=0;
     #ifdef MPI_VERSION
-    rank = MPI::COMM_WORLD.Get_rank();
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     #endif
 
 	ghostswap(mcGrid);

--- a/examples/coarsening/zener_pinning/anisotropic/phase_field/Makefile
+++ b/examples/coarsening/zener_pinning/anisotropic/phase_field/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../../../include
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 zener: zener.cpp

--- a/examples/coarsening/zener_pinning/anisotropic/phase_field/Makefile
+++ b/examples/coarsening/zener_pinning/anisotropic/phase_field/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../../../include
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -I $(incdir)
+flags = -O3 -Wall -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/coarsening/zener_pinning/anisotropic/phase_field/zener.cpp
+++ b/examples/coarsening/zener_pinning/anisotropic/phase_field/zener.cpp
@@ -106,7 +106,7 @@ template <int dim, typename T> void update(grid<dim,vector<T> >& oldGrid, int st
 {
 	int rank=0;
     #ifdef MPI_VERSION
-    rank = MPI::COMM_WORLD.Get_rank();
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     #endif
 
 	ghostswap(oldGrid);

--- a/examples/coarsening/zener_pinning/anisotropic/sparsePF/Makefile
+++ b/examples/coarsening/zener_pinning/anisotropic/sparsePF/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../../../include
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 zener: zener.cpp

--- a/examples/coarsening/zener_pinning/anisotropic/sparsePF/Makefile
+++ b/examples/coarsening/zener_pinning/anisotropic/sparsePF/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../../../include
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -I $(incdir)
+flags = -O3 -Wall -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/coarsening/zener_pinning/anisotropic/sparsePF/zener.cpp
+++ b/examples/coarsening/zener_pinning/anisotropic/sparsePF/zener.cpp
@@ -100,7 +100,7 @@ template <int dim, typename T> void update(grid<dim,sparse<T> >& oldGrid, int st
 {
 	int rank=0;
     #ifdef MPI_VERSION
-    rank = MPI::COMM_WORLD.Get_rank();
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     #endif
 
 	ghostswap(oldGrid);

--- a/examples/coarsening/zener_pinning/isotropic/Monte_Carlo/Makefile
+++ b/examples/coarsening/zener_pinning/isotropic/Monte_Carlo/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../../../include
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 zener: zener.cpp

--- a/examples/coarsening/zener_pinning/isotropic/Monte_Carlo/Makefile
+++ b/examples/coarsening/zener_pinning/isotropic/Monte_Carlo/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../../../include
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -I $(incdir)
+flags = -O3 -Wall -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/coarsening/zener_pinning/isotropic/Monte_Carlo/zener.cpp
+++ b/examples/coarsening/zener_pinning/isotropic/Monte_Carlo/zener.cpp
@@ -90,7 +90,7 @@ template <int dim> void update(grid<dim,int>& mcGrid, int steps)
 {
 	int rank=0;
     #ifdef MPI_VERSION
-    rank = MPI::COMM_WORLD.Get_rank();
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     #endif
 
 	ghostswap(mcGrid);

--- a/examples/coarsening/zener_pinning/isotropic/phase_field/Makefile
+++ b/examples/coarsening/zener_pinning/isotropic/phase_field/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../../../include
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 zener: zener.cpp

--- a/examples/coarsening/zener_pinning/isotropic/phase_field/Makefile
+++ b/examples/coarsening/zener_pinning/isotropic/phase_field/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../../../include
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -I $(incdir)
+flags = -O3 -Wall -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/coarsening/zener_pinning/isotropic/phase_field/zener.cpp
+++ b/examples/coarsening/zener_pinning/isotropic/phase_field/zener.cpp
@@ -105,7 +105,7 @@ template <int dim, typename T> void update(grid<dim,vector<T> >& oldGrid, int st
 {
 	int rank=0;
     #ifdef MPI_VERSION
-    rank = MPI::COMM_WORLD.Get_rank();
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     #endif
 
 	ghostswap(oldGrid);

--- a/examples/coarsening/zener_pinning/isotropic/sparsePF/Makefile
+++ b/examples/coarsening/zener_pinning/isotropic/sparsePF/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../../../include
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 zener: zener.cpp

--- a/examples/coarsening/zener_pinning/isotropic/sparsePF/Makefile
+++ b/examples/coarsening/zener_pinning/isotropic/sparsePF/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../../../include
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -I $(incdir)
+flags = -O3 -Wall -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/coarsening/zener_pinning/isotropic/sparsePF/zener.cpp
+++ b/examples/coarsening/zener_pinning/isotropic/sparsePF/zener.cpp
@@ -99,7 +99,7 @@ template <int dim, typename T> void update(grid<dim,sparse<T> >& oldGrid, int st
 {
 	int rank=0;
     #ifdef MPI_VERSION
-    rank = MPI::COMM_WORLD.Get_rank();
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     #endif
 
 	ghostswap(oldGrid);

--- a/examples/differential_equations/elliptic/Poisson/Makefile
+++ b/examples/differential_equations/elliptic/Poisson/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../../include
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h 
+pflags = $(flags) -include mpi.h
 
 # the program
 poisson: poisson.cpp

--- a/examples/differential_equations/elliptic/Poisson/Makefile
+++ b/examples/differential_equations/elliptic/Poisson/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../../include
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 poisson: poisson.cpp

--- a/examples/phase_transitions/allen-cahn/Makefile
+++ b/examples/phase_transitions/allen-cahn/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../include
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -I $(incdir)
+flags = -O3 -Wall -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/phase_transitions/allen-cahn/Makefile
+++ b/examples/phase_transitions/allen-cahn/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../include
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 allen-cahn: allen-cahn.cpp

--- a/examples/phase_transitions/allen-cahn/allen-cahn.cpp
+++ b/examples/phase_transitions/allen-cahn/allen-cahn.cpp
@@ -48,7 +48,7 @@ template <int dim, typename T> void update(grid<dim,T>& oldGrid, int steps)
 {
 	int rank=0;
     #ifdef MPI_VERSION
-    rank = MPI::COMM_WORLD.Get_rank();
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     #endif
 
 	ghostswap(oldGrid);

--- a/examples/phase_transitions/cahn-hilliard/convex_splitting/Makefile
+++ b/examples/phase_transitions/cahn-hilliard/convex_splitting/Makefile
@@ -10,7 +10,7 @@ incdir = ../../../../include
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -DVANILLA -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 cahn-hilliard: cahn-hilliard.cpp

--- a/examples/phase_transitions/cahn-hilliard/convex_splitting/Makefile
+++ b/examples/phase_transitions/cahn-hilliard/convex_splitting/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../../include
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -DVANILLA -I $(incdir)
+flags = -O3 -Wall -DVANILLA -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/phase_transitions/cahn-hilliard/convex_splitting/cahn-hilliard.cpp
+++ b/examples/phase_transitions/cahn-hilliard/convex_splitting/cahn-hilliard.cpp
@@ -180,7 +180,7 @@ template<int dim, typename T> void reportEnergy(const MMSP::grid<dim,vector<T> >
 {
 	int rank=0;
 	#ifdef MPI_VERSION
-	rank = MPI::COMM_WORLD.Get_rank();
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 	#endif
 
 	double dV = 1.0;
@@ -205,8 +205,8 @@ template<int dim, typename T> void reportEnergy(const MMSP::grid<dim,vector<T> >
 	#ifdef MPI_VERSION
 	double localEnergy = energy;
 	double localMass = mass;
-	MPI::COMM_WORLD.Reduce(&localEnergy, &energy, 1, MPI_DOUBLE, MPI_SUM, 0);
-	MPI::COMM_WORLD.Reduce(&localMass, &mass, 1, MPI_DOUBLE, MPI_SUM, 0);
+	MPI_Reduce(&localEnergy, &energy, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+	MPI_Reduce(&localMass, &mass, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
 	#endif
 	//if (rank==0)
 	//	std::cout<<'0'<<'\t'<<dV*energy<<'\t'<<dV*mass<<std::endl;
@@ -278,7 +278,7 @@ void update(grid<dim,vector<T> >& oldGrid, int steps)
 {
 	int rank=0;
 	#ifdef MPI_VERSION
-	rank = MPI::COMM_WORLD.Get_rank();
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 	#endif
 
 	ghostswap(oldGrid);
@@ -296,7 +296,7 @@ void update(grid<dim,vector<T> >& oldGrid, int steps)
 	double gridSize = static_cast<double>(nodes(oldGrid));
 	#ifdef MPI_VERSION
 	double localGridSize = gridSize;
-	MPI::COMM_WORLD.Allreduce(&localGridSize, &gridSize, 1, MPI_DOUBLE, MPI_SUM);
+	MPI_Allreduce(&localGridSize, &gridSize, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
 	#endif
 
 	double lapWeight = 0.0;
@@ -416,9 +416,9 @@ void update(grid<dim,vector<T> >& oldGrid, int steps)
 
 				#ifdef MPI_VERSION
 				double localResidual=residual;
-				MPI::COMM_WORLD.Allreduce(&localResidual, &residual, 1, MPI_DOUBLE, MPI_SUM);
+				MPI_Allreduce(&localResidual, &residual, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
 				double localNormB=normB;
-				MPI::COMM_WORLD.Allreduce(&localNormB, &normB, 1, MPI_DOUBLE, MPI_SUM);
+				MPI_Allreduce(&localNormB, &normB, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
 				#endif
 
 				residual = sqrt(residual/normB)/(2.0*gridSize);
@@ -429,7 +429,8 @@ void update(grid<dim,vector<T> >& oldGrid, int steps)
 		if (iter==max_iter) {
 			if (rank==0)
 				std::cerr<<"    Solver stagnated on step "<<step<<": "<<iter<<" iterations with residual="<<residual<<std::endl;
-				MMSP::Abort(-1);
+
+            MMSP::Abort(-1);
 		}
 
 		/*
@@ -448,8 +449,8 @@ void update(grid<dim,vector<T> >& oldGrid, int steps)
 		#ifdef MPI_VERSION
 		double localEnergy = energy;
 		double localMass = mass;
-		MPI::COMM_WORLD.Reduce(&localEnergy, &energy, 1, MPI_DOUBLE, MPI_SUM, 0);
-		MPI::COMM_WORLD.Reduce(&localMass, &mass, 1, MPI_DOUBLE, MPI_SUM, 0);
+		MPI_Reduce(&localEnergy, &energy, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+		MPI_Reduce(&localMass, &mass, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
 		#endif
 		if (rank==0)
 			std::cout<<iter<<'\t'<<dV*energy<<'\t'<<dV*mass<<std::endl;

--- a/examples/phase_transitions/cahn-hilliard/explicit/Makefile
+++ b/examples/phase_transitions/cahn-hilliard/explicit/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../../include
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 cahn-hilliard: cahn-hilliard.cpp

--- a/examples/phase_transitions/cahn-hilliard/explicit/Makefile
+++ b/examples/phase_transitions/cahn-hilliard/explicit/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../../include
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -I $(incdir)
+flags = -O3 -Wall -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/phase_transitions/cahn-hilliard/explicit/cahn-hilliard.cpp
+++ b/examples/phase_transitions/cahn-hilliard/explicit/cahn-hilliard.cpp
@@ -48,7 +48,7 @@ template <int dim, typename T> void update(grid<dim,T>& oldGrid, int steps)
 {
 	int rank=0;
     #ifdef MPI_VERSION
-    rank = MPI::COMM_WORLD.Get_rank();
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     #endif
 
 	ghostswap(oldGrid);

--- a/examples/phase_transitions/model_A/Makefile
+++ b/examples/phase_transitions/model_A/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../include
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 model_A: model_A.cpp

--- a/examples/phase_transitions/model_A/Makefile
+++ b/examples/phase_transitions/model_A/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../include
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -I $(incdir)
+flags = -O3 -Wall -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/phase_transitions/model_A/model_A.cpp
+++ b/examples/phase_transitions/model_A/model_A.cpp
@@ -75,7 +75,7 @@ template <int dim, typename T> void update(grid<dim,T>& oldGrid, int steps)
 {
 	int rank=0;
     #ifdef MPI_VERSION
-    rank = MPI::COMM_WORLD.Get_rank();
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     #endif
 
 	ghostswap(oldGrid);

--- a/examples/phase_transitions/model_B/Makefile
+++ b/examples/phase_transitions/model_B/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../include
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -I $(incdir)
+flags = -O3 -Wall -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/phase_transitions/model_B/Makefile
+++ b/examples/phase_transitions/model_B/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../include
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 model_B: model_B.cpp

--- a/examples/phase_transitions/model_B/model_B.cpp
+++ b/examples/phase_transitions/model_B/model_B.cpp
@@ -75,7 +75,7 @@ template <int dim, typename T> void update(grid<dim,T>& oldGrid, int steps)
 {
 	int rank=0;
     #ifdef MPI_VERSION
-    rank = MPI::COMM_WORLD.Get_rank();
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     #endif
 
 	ghostswap(oldGrid);

--- a/examples/phase_transitions/solidification/anisotropic/Makefile
+++ b/examples/phase_transitions/solidification/anisotropic/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../../include
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 solidification.out: solidification.cpp

--- a/examples/phase_transitions/solidification/anisotropic/Makefile
+++ b/examples/phase_transitions/solidification/anisotropic/Makefile
@@ -6,9 +6,9 @@
 incdir = ../../../../include
 
 # compilers/flags
-compiler = g++ -O3
-pcompiler = mpic++ -O3
-flags = -I $(incdir)
+compiler = g++
+pcompiler = mpic++
+flags = -O3 -Wall -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/phase_transitions/solidification/anisotropic/solidification.cpp
+++ b/examples/phase_transitions/solidification/anisotropic/solidification.cpp
@@ -50,11 +50,11 @@ void generate(int dim, const char* filename)
 template <int dim, typename T> void update(grid<dim,vector<T> >& oldGrid, int steps)
 {
 	int id = 0;
-	int np = 1;
 	static int iterations = 1;
 	#ifdef MPI_VERSION
-	id = MPI::COMM_WORLD.Get_rank();
-	np = MPI::COMM_WORLD.Get_size();
+    int np;
+    MPI_Comm_rank(MPI_COMM_WORLD, &id);
+    MPI_Comm_size(MPI_COMM_WORLD, &np);
 	#endif
 
 	ghostswap(oldGrid);
@@ -87,8 +87,6 @@ template <int dim, typename T> void update(grid<dim,vector<T> >& oldGrid, int st
 
 	ghostswap(oldGrid);
 
-	int minus = 0;
-	int plus = 0;
 	for (int step = 0; step < steps; step++) {
 		if (id == 0)
 			print_progress(step, steps);

--- a/examples/phase_transitions/spinodal/Makefile
+++ b/examples/phase_transitions/spinodal/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../include
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -I $(incdir)
+flags = -O3 -Wall -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/phase_transitions/spinodal/Makefile
+++ b/examples/phase_transitions/spinodal/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../include
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 spinodal: spinodal.cpp

--- a/examples/phase_transitions/spinodal/spinodal.cpp
+++ b/examples/phase_transitions/spinodal/spinodal.cpp
@@ -75,7 +75,7 @@ template <int dim, typename T> void update(grid<dim,T>& oldGrid, int steps)
 {
 	int rank=0;
     #ifdef MPI_VERSION
-    rank = MPI::COMM_WORLD.Get_rank();
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     #endif
 
 	ghostswap(oldGrid);

--- a/examples/statistical_mechanics/Heisenberg/Makefile
+++ b/examples/statistical_mechanics/Heisenberg/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../include/
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -I $(incdir)
+flags = -O3 -Wall -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/statistical_mechanics/Heisenberg/Makefile
+++ b/examples/statistical_mechanics/Heisenberg/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../include/
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 heisenberg: heisenberg.cpp

--- a/examples/statistical_mechanics/Heisenberg/heisenberg.cpp
+++ b/examples/statistical_mechanics/Heisenberg/heisenberg.cpp
@@ -63,7 +63,7 @@ template <int dim, typename T> void update(grid<dim,vector<T> >& spinGrid, int s
 {
 	int rank=0;
     #ifdef MPI_VERSION
-    rank = MPI::COMM_WORLD.Get_rank();
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     #endif
 
 	ghostswap(spinGrid);

--- a/examples/statistical_mechanics/Ising/Makefile
+++ b/examples/statistical_mechanics/Ising/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../include/
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 ising: ising.cpp

--- a/examples/statistical_mechanics/Ising/Makefile
+++ b/examples/statistical_mechanics/Ising/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../include/
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -I $(incdir)
+flags = -O3 -Wall -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/statistical_mechanics/Ising/ising.cpp
+++ b/examples/statistical_mechanics/Ising/ising.cpp
@@ -47,7 +47,7 @@ template <int dim> void update(grid<dim,int>& spinGrid, int steps)
 {
 	int rank=0;
     #ifdef MPI_VERSION
-    rank = MPI::COMM_WORLD.Get_rank();
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     #endif
 
 	ghostswap(spinGrid);

--- a/examples/statistical_mechanics/Potts/Makefile
+++ b/examples/statistical_mechanics/Potts/Makefile
@@ -8,7 +8,7 @@ incdir = ../../../include/
 # compilers/flags
 compiler = g++
 pcompiler = mpic++
-flags = -O3 -I $(incdir)
+flags = -O3 -Wall -I $(incdir)
 pflags = $(flags) -include mpi.h
 
 # the program

--- a/examples/statistical_mechanics/Potts/Makefile
+++ b/examples/statistical_mechanics/Potts/Makefile
@@ -9,7 +9,7 @@ incdir = ../../../include/
 compiler = g++
 pcompiler = mpic++
 flags = -O3 -Wall -I $(incdir)
-pflags = $(flags) -include mpi.h
+pflags = $(flags) -fpermissive -include mpi.h
 
 # the program
 potts: potts.cpp

--- a/examples/statistical_mechanics/Potts/potts.cpp
+++ b/examples/statistical_mechanics/Potts/potts.cpp
@@ -48,7 +48,7 @@ template <int dim> void update(grid<dim,int>& spinGrid, int steps)
 {
 	int rank=0;
     #ifdef MPI_VERSION
-    rank = MPI::COMM_WORLD.Get_rank();
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     #endif
 
 	ghostswap(spinGrid);

--- a/include/MMSP.grid.cpp
+++ b/include/MMSP.grid.cpp
@@ -1593,7 +1593,8 @@ template<int dim, typename T> void grid<dim,T>::output(const char* filename) con
 
 		// Compute file offsets based on buffer sizes
 		datasizes = new unsigned long[np];
-		MPI_Allgather(&size_of_buffer, 1, MPI_UNSIGNED_LONG, datasizes, 1, MPI_UNSIGNED_LONG, MPI_COMM_WORLD);
+        const unsigned long* size_pointer = &size_of_buffer; // because OpenMPI is annoying about the first pointer being const
+		MPI_Allgather(size_pointer, 1, MPI_UNSIGNED_LONG, datasizes, 1, MPI_UNSIGNED_LONG, MPI_COMM_WORLD);
 		#ifdef GRIDDEBUG
 		if (rank==0) std::cout<<"Synchronized data sizes."<<std::endl;
 		#endif

--- a/include/MMSP.grid.cpp
+++ b/include/MMSP.grid.cpp
@@ -1593,8 +1593,7 @@ template<int dim, typename T> void grid<dim,T>::output(const char* filename) con
 
 		// Compute file offsets based on buffer sizes
 		datasizes = new unsigned long[np];
-        const unsigned long* size_pointer = &size_of_buffer; // because OpenMPI is annoying about the first pointer being const
-		MPI_Allgather(size_pointer, 1, MPI_UNSIGNED_LONG, datasizes, 1, MPI_UNSIGNED_LONG, MPI_COMM_WORLD);
+		MPI_Allgather(&size_of_buffer, 1, MPI_UNSIGNED_LONG, datasizes, 1, MPI_UNSIGNED_LONG, MPI_COMM_WORLD);
 		#ifdef GRIDDEBUG
 		if (rank==0) std::cout<<"Synchronized data sizes."<<std::endl;
 		#endif

--- a/include/MMSP.main.hpp
+++ b/include/MMSP.main.hpp
@@ -50,7 +50,7 @@ int main(int argc, char* argv[]) {
 	// _exactly once_, making this the proper place for it.
 	int rank = 0;
 	#ifdef MPI_VERSION
-	rank = MPI::COMM_WORLD.Get_rank();
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 	#endif
 	srand(time(NULL)+rank);
 

--- a/test/MMSP.exampleTestSuite.cpp
+++ b/test/MMSP.exampleTestSuite.cpp
@@ -34,13 +34,13 @@
 
 int main(int argc, char* argv[]) {
 	MMSP::Init(argc, argv);
-  testing::InitGoogleTest(&argc, argv);
+    testing::InitGoogleTest(&argc, argv);
 	int rank=0;
 	#ifdef MPI_VERSION
-	rank=MPI::COMM_WORLD.Get_rank();
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 	#endif
 	srand(time(NULL)+rank);
-  int result = RUN_ALL_TESTS();
-  MMSP::Finalize();
-  return result;
+    int result = RUN_ALL_TESTS();
+    MMSP::Finalize();
+    return result;
 }

--- a/test/MMSP.unitTestSuite.hpp
+++ b/test/MMSP.unitTestSuite.hpp
@@ -117,7 +117,8 @@ TYPED_TEST(gridTest, testSize) {
 	#ifndef MPI_VERSION
 	EXPECT_EQ(MMSP::nodes(this->grid1D),64);
 	#else
-	int np = MPI::COMM_WORLD.Get_size();
+	int np = 0;
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
 	EXPECT_LE(MMSP::nodes(this->grid1D),1+64/np);
 	#endif
 	EXPECT_EQ(this->grid1D.buffer_size(),MMSP::nodes(this->grid1D)*sizeof(TypeParam));

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -13,8 +13,9 @@ int main(int argc, char* argv[])
 	#endif
 
 	#ifdef MPI_VERSION
-	int id = MPI::COMM_WORLD.Get_rank();
-	int np = MPI::COMM_WORLD.Get_size();
+	int id = 0, np = 1;
+    MPI_Comm_rank(MPI_COMM_WORLD, &id);
+    MPI_Comm_size(MPI_COMM_WORLD, &np);
 	std::cout<<"This is a test (processor "<<id<<" of "<<np<<")."<<std::endl;
 	#endif
 


### PR DESCRIPTION
This PR converts all MPI function calls from C++ to C bindings.
The C++ bindings are [deprecated](https://www.mpi-forum.org/docs/mpi-3.1/mpi31-report/node405.htm#Node405), making this a necessary overhaul.

Fixes 71.